### PR TITLE
Remove AIP-11 in favor of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Apache Airflow website
 ======================
 
-[![Build Status](https://travis-ci.org/apache/airflow-site.svg?branch=aip-11)](https://travis-ci.org/apache/airflow-site)
+[![Build Status](https://travis-ci.org/apache/airflow-site.svg)](https://travis-ci.org/apache/airflow-site)
 
 This is a repository of [Apache Airflow website](https://airflow.apache.org).
 The repository of Apache Airflow can be found [here](https://github.com/apache/airflow/).

--- a/landing-pages/site/content/en/blog/airflow-survey/index.md
+++ b/landing-pages/site/content/en/blog/airflow-survey/index.md
@@ -330,5 +330,5 @@ for you here:
  - Processed: https://storage.googleapis.com/airflow-survey/airflow_survey_processed.csv
 
 The processed data includes multi-choice options one-hot encoded. If you find any interesting
-insight, please update the article ([make PR](https://github.com/apache/airflow-site/blob/aip-11/CONTRIBUTE.md)
+insight, please update the article ([make PR](https://github.com/apache/airflow-site/blob/master/CONTRIBUTE.md)
 to Airflow site).

--- a/landing-pages/site/content/en/blog/announcing-new-website.md
+++ b/landing-pages/site/content/en/blog/announcing-new-website.md
@@ -22,10 +22,10 @@ to be translated into many languages. This is our effort to foster a more inclus
 Apache Airflow, and we look forward to seeing contributions in Spanish, Chinese, Russian, and other languages as well!
 
 We built our website on Docsy, a platform that is easy to use and contribute to. Follow
-[these steps](https://github.com/apache/airflow-site/blob/aip-11/README.md) to set up your environment and
+[these steps](https://github.com/apache/airflow-site/blob/master/README.md) to set up your environment and
 to create your first pull request. You may also use
 the new website for your own open source project as a template.
-All of our [code is open and hosted on Github](https://github.com/apache/airflow-site/tree/aip-11).
+All of our [code is open and hosted on Github](https://github.com/apache/airflow-site/tree/master).
 
 Share your questions, comments, and suggestions with us, to help us improve the website.
 We hope that this new design makes finding documentation about Airflow easier,


### PR DESCRIPTION
I believe this is a relic from the past. I tried to click the _Suggest a change on this page_ on here: https://airflow.apache.org/community/

But I got a 404.