### PR TITLE
Added labels to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,6 +20,10 @@
 github:
   description: "Apache Airflow Website"
   homepage: https://airflow.apache.org/
+  labels:
+    - apache
+    - airflow
+    - hugo
 
   enabled_merge_buttons:
     squash: true


### PR DESCRIPTION
This adds labels to the repository metadata. This can help with discovering the technology used behind websites.

Also: [this GitHub query](https://github.com/search?q=topic%3Ahugo+org%3Aapache&type=Repositories) will then list the airflow site as well (using Hugo).