### PR TITLE
Redirect Airflow 1.10.10 API/Macros/CLI refs to new URLs

### DIFF
--- a/landing-pages/site/static/.htaccess
+++ b/landing-pages/site/static/.htaccess
@@ -1,3 +1,5 @@
+RedirectMatch Permanent ^/docs/(stable|1.10.10)/api(\.html)?$ "https://airflow.apache.org/docs/$1/rest-api-ref"
+RedirectMatch Permanent ^/docs/(stable|1.10.10)/(cli|macros)(\.html)?$ "https://airflow.apache.org/docs/$1/$2-ref"
 RedirectMatch Permanent ^/((_api|_images|_modules|_sources|_static|howto)/.*)$ "https://airflow.apache.org/docs/stable/$1"
 RedirectMatch Permanent ^/((1.10.1|1.10.2|1.10.3|1.10.4|1.10.5|1.10.6|1.10.7|1.10.8|1.10.9|1.10.10)/.*)$ "https://airflow.apache.org/docs/$1"
 RedirectMatch Permanent ^/((api|changelog|cli|concepts|errors|faq|genindex|http-routingtable|installation|integration|kubernetes|license|lineage|macros|metrics|plugins|privacy_notice|profiling|project|py-modindex|scheduler|search|security|start|timezone|tutorial|ui)(\.html)?)$ "https://airflow.apache.org/docs/stable/$1"


### PR DESCRIPTION
I have already published this on asf-site branch so you can check the below URLs to verify they work fine:

https://airflow.apache.org/docs/stable/cli -> https://airflow.apache.org/docs/stable/cli-ref
https://airflow.apache.org/docs/1.10.10/api -> https://airflow.apache.org/docs/1.10.10/rest-api-ref
https://airflow.apache.org/docs/stable/api -> https://airflow.apache.org/docs/stable/rest-api-ref
https://airflow.apache.org/docs/stable/macros -> https://airflow.apache.org/docs/stable/macros-ref

PRing for Master so that these redirects are not deleted when the website is re-generated