### PR TITLE
Remove duplicate text under Principles section

### DIFF
--- a/landing-pages/site/layouts/index.html
+++ b/landing-pages/site/layouts/index.html
@@ -48,7 +48,7 @@
             {{ partial "text-with-icon" (dict "logo_path" "icons/scalable-icon.svg" "header" "Scalable" "text" "Airflow has a modular architecture and uses a message queue to orchestrate an arbitrary number of workers. Airflow is ready to scale to infinity.") }}
             {{ partial "text-with-icon" (dict "logo_path" "icons/dynamic-icon.svg" "header" "Dynamic" "text" "Airflow pipelines are defined in Python, allowing for dynamic pipeline generation. This allows for writing code that instantiates pipelines dynamically.") }}
             {{ partial "text-with-icon" (dict "logo_path" "icons/extensible-icon.svg" "header" "Extensible" "text" "Easily define your own operators and extend libraries to fit the level of abstraction that suits your environment.") }}
-            {{ partial "text-with-icon" (dict "logo_path" "icons/elegant-icon.svg" "header" "Elegant" "text" "Airflow pipelines are lean and explicit. Airflow pipelines are lean and explicit. Parametrization is built into its core using the powerful Jinja templating engine.") }}
+            {{ partial "text-with-icon" (dict "logo_path" "icons/elegant-icon.svg" "header" "Elegant" "text" "Airflow pipelines are lean and explicit. Parametrization is built into its core using the powerful Jinja templating engine.") }}
         </div>
     </div>
     <div>


### PR DESCRIPTION
Following line is written twice under "Principles ->Elegant" section on the Homepage: "Airflow pipelines are lean and explicit".
This change is for fixing the same.