### PR TITLE
Add Google Analytics to docs

### DIFF
--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/emr_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/fs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/imap_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/jira_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/redis_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/segment_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/kubernetes/secret.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/kubernetes/secret.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/databricks_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/druid_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/ecs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/jira_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/qubole_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sftp_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/ssh_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/vertica_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/operators/winrm_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/cassandra_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/cassandra_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/file_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.1/_modules/airflow/executors/celery_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.1/_modules/airflow/executors/local_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.1/_modules/airflow/executors/sequential_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/S3_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/dbapi_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/docker_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/druid_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/hdfs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/hive_hooks.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/http_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/jdbc_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/mssql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/mysql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/oracle_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/pig_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/postgres_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/presto_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/samba_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/slack_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/sqlite_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/webhdfs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.1/_modules/airflow/hooks/zendesk_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/macros.html
+++ b/docs-archive/1.10.1/_modules/airflow/macros.html
@@ -32,7 +32,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.1/_modules/airflow/macros/hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/models.html
+++ b/docs-archive/1.10.1/_modules/airflow/models.html
@@ -32,7 +32,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/bash_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/dagrun_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/docker_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/druid_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/dummy_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/email_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/generic_transfer.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/hive_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/hive_stats_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/hive_to_druid.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/hive_to_mysql.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/hive_to_samba_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/http_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/jdbc_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/latest_only_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/mssql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/mssql_to_hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/mysql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/mysql_to_hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/oracle_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/pig_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/postgres_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/presto_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/presto_to_mysql.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/python_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/s3_file_transform_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/s3_to_hive_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/slack_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/sqlite_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/operators/subdag_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/base_sensor_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/external_task_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/hdfs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/hive_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/http_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/s3_key_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/sql_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/time_delta_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/time_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.1/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/_modules/index.html
+++ b/docs-archive/1.10.1/_modules/index.html
@@ -32,7 +32,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/api.html
+++ b/docs-archive/1.10.1/api.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/cli.html
+++ b/docs-archive/1.10.1/cli.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/code.html
+++ b/docs-archive/1.10.1/code.html
@@ -33,7 +33,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/concepts.html
+++ b/docs-archive/1.10.1/concepts.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/faq.html
+++ b/docs-archive/1.10.1/faq.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/genindex.html
+++ b/docs-archive/1.10.1/genindex.html
@@ -33,7 +33,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/executor/use-celery.html
+++ b/docs-archive/1.10.1/howto/executor/use-celery.html
@@ -34,7 +34,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/executor/use-dask.html
+++ b/docs-archive/1.10.1/howto/executor/use-dask.html
@@ -34,7 +34,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/executor/use-mesos.html
+++ b/docs-archive/1.10.1/howto/executor/use-mesos.html
@@ -34,7 +34,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/index.html
+++ b/docs-archive/1.10.1/howto/index.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/initialize-database.html
+++ b/docs-archive/1.10.1/howto/initialize-database.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/manage-connections.html
+++ b/docs-archive/1.10.1/howto/manage-connections.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/operator.html
+++ b/docs-archive/1.10.1/howto/operator.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/run-with-systemd.html
+++ b/docs-archive/1.10.1/howto/run-with-systemd.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/run-with-upstart.html
+++ b/docs-archive/1.10.1/howto/run-with-upstart.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/secure-connections.html
+++ b/docs-archive/1.10.1/howto/secure-connections.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/set-config.html
+++ b/docs-archive/1.10.1/howto/set-config.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/use-test-config.html
+++ b/docs-archive/1.10.1/howto/use-test-config.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/howto/write-logs.html
+++ b/docs-archive/1.10.1/howto/write-logs.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/index.html
+++ b/docs-archive/1.10.1/index.html
@@ -33,7 +33,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/installation.html
+++ b/docs-archive/1.10.1/installation.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/integration.html
+++ b/docs-archive/1.10.1/integration.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/kubernetes.html
+++ b/docs-archive/1.10.1/kubernetes.html
@@ -32,7 +32,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/license.html
+++ b/docs-archive/1.10.1/license.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/lineage.html
+++ b/docs-archive/1.10.1/lineage.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/plugins.html
+++ b/docs-archive/1.10.1/plugins.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/profiling.html
+++ b/docs-archive/1.10.1/profiling.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/project.html
+++ b/docs-archive/1.10.1/project.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/py-modindex.html
+++ b/docs-archive/1.10.1/py-modindex.html
@@ -35,7 +35,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/scheduler.html
+++ b/docs-archive/1.10.1/scheduler.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/search.html
+++ b/docs-archive/1.10.1/search.html
@@ -32,7 +32,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/security.html
+++ b/docs-archive/1.10.1/security.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/start.html
+++ b/docs-archive/1.10.1/start.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/timezone.html
+++ b/docs-archive/1.10.1/timezone.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/tutorial.html
+++ b/docs-archive/1.10.1/tutorial.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.1/ui.html
+++ b/docs-archive/1.10.1/ui.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.10/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/gdrive_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/gdrive_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/docker_swarm_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/docker_swarm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/druid_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/jira_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/secrets/aws_systems_manager/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/secrets/aws_systems_manager/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/secrets/gcp_secrets_manager/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/secrets/gcp_secrets_manager/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/secrets/hashicorp_vault/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/secrets/hashicorp_vault/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/secrets/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/secrets/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/base_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/celery_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/dask_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/debug_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/debug_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/local_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/executors/sequential_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/S3_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/dbapi_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/docker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/druid_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/hdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/hive_hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/http_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/mssql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/mysql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/oracle_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/pig_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/postgres_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/presto_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/samba_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/slack_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/sqlite_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/webhdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.10/_api/airflow/hooks/zendesk_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/base/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/baseoperator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/chart/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/crypto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/dagbag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/dagcode/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/dagcode/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/dagpickle/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/dagrun/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/errors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/knownevent/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/kubernetes/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/log/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/pool/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/renderedtifields/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/renderedtifields/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/serialized_dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/skipmixin/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/slamiss/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/taskfail/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/taskinstance/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/taskreschedule/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/user/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/variable/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.10/_api/airflow/models/xcom/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/bash_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/branch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/dagrun_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/docker_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/druid_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/dummy_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/email_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/generic_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/hive_stats_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/hive_to_druid/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/hive_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/http_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/latest_only_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/mssql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/mssql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/mysql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/oracle_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/papermill_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/pig_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/postgres_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/presto_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/presto_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/python_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/slack_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/sqlite_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/operators/subdag_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/secrets/base_secrets/index.html
+++ b/docs-archive/1.10.10/_api/airflow/secrets/base_secrets/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/secrets/environment_variables/index.html
+++ b/docs-archive/1.10.10/_api/airflow/secrets/environment_variables/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/secrets/index.html
+++ b/docs-archive/1.10.10/_api/airflow/secrets/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/secrets/metastore/index.html
+++ b/docs-archive/1.10.10/_api/airflow/secrets/metastore/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/base_sensor_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/external_task_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/http_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/s3_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/sql_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/time_delta_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/time_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.10/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_api/index.html
+++ b/docs-archive/1.10.10/_api/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.10/_modules/airflow/configuration.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/executors/mesos_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/emr_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/fs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gdrive_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/gdrive_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/imap_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/jira_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/redis_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/segment_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/databricks_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/docker_swarm_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/docker_swarm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/druid_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/dynamodb_to_s3.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/dynamodb_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/ecs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/jira_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/qubole_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/ssh_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/vertica_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/operators/winrm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/secrets/aws_systems_manager.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/secrets/aws_systems_manager.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/secrets/gcp_secrets_manager.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/secrets/gcp_secrets_manager.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/secrets/hashicorp_vault.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/secrets/hashicorp_vault.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/file_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/python_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/example_dags/example_bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/example_dags/example_external_task_marker_dag.html
+++ b/docs-archive/1.10.10/_modules/airflow/example_dags/example_external_task_marker_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/example_dags/example_python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/example_dags/tutorial.html
+++ b/docs-archive/1.10.10/_modules/airflow/example_dags/tutorial.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.10/_modules/airflow/exceptions.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors/base_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors/celery_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors/dask_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors/debug_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors/debug_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors/local_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.10/_modules/airflow/executors/sequential_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/S3_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/dbapi_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/docker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/druid_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/hdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/hive_hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/http_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/mssql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/mysql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/oracle_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/pig_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/postgres_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/presto_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/samba_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/slack_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/sqlite_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/webhdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.10/_modules/airflow/hooks/zendesk_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/macros.html
+++ b/docs-archive/1.10.10/_modules/airflow/macros.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.10/_modules/airflow/macros/hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models.html
+++ b/docs-archive/1.10.10/_modules/airflow/models.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/base.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/baseoperator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/chart.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/connection.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/crypto.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/dagbag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/dagcode.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/dagcode.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/dagpickle.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/dagrun.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/errors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/knownevent.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/kubernetes.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/log.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/pool.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/renderedtifields.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/renderedtifields.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/serialized_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/skipmixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/slamiss.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/taskfail.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/taskinstance.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/taskreschedule.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/user.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/variable.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.10/_modules/airflow/models/xcom.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/branch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/dagrun_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/docker_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/druid_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/dummy_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/email_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/generic_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/hive_stats_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/hive_to_druid.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/hive_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/hive_to_samba_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/http_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/latest_only_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/mssql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/mssql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/mysql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/oracle_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/pig_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/postgres_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/presto_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/presto_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/s3_file_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/s3_to_hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/slack_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/sqlite_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/operators/subdag_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/secrets.html
+++ b/docs-archive/1.10.10/_modules/airflow/secrets.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/secrets/base_secrets.html
+++ b/docs-archive/1.10.10/_modules/airflow/secrets/base_secrets.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/secrets/environment_variables.html
+++ b/docs-archive/1.10.10/_modules/airflow/secrets/environment_variables.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/secrets/metastore.html
+++ b/docs-archive/1.10.10/_modules/airflow/secrets/metastore.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/base_sensor_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/external_task_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/http_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/s3_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/sql_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/time_delta_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/time_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.10/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.10/_modules/airflow/utils/log/logging_mixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/_modules/index.html
+++ b/docs-archive/1.10.10/_modules/index.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/best-practices.html
+++ b/docs-archive/1.10.10/best-practices.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/changelog.html
+++ b/docs-archive/1.10.10/changelog.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/cli-ref.html
+++ b/docs-archive/1.10.10/cli-ref.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/concepts.html
+++ b/docs-archive/1.10.10/concepts.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/configurations-ref.html
+++ b/docs-archive/1.10.10/configurations-ref.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/dag-serialization.html
+++ b/docs-archive/1.10.10/dag-serialization.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/errors.html
+++ b/docs-archive/1.10.10/errors.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/executor/celery.html
+++ b/docs-archive/1.10.10/executor/celery.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/executor/dask.html
+++ b/docs-archive/1.10.10/executor/dask.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/executor/debug.html
+++ b/docs-archive/1.10.10/executor/debug.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/executor/index.html
+++ b/docs-archive/1.10.10/executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/executor/kubernetes.html
+++ b/docs-archive/1.10.10/executor/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/executor/mesos.html
+++ b/docs-archive/1.10.10/executor/mesos.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/faq.html
+++ b/docs-archive/1.10.10/faq.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/genindex.html
+++ b/docs-archive/1.10.10/genindex.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/check-health.html
+++ b/docs-archive/1.10.10/howto/check-health.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/aws.html
+++ b/docs-archive/1.10.10/howto/connection/aws.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/gcp.html
+++ b/docs-archive/1.10.10/howto/connection/gcp.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.10/howto/connection/gcp_sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/grpc.html
+++ b/docs-archive/1.10.10/howto/connection/grpc.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/index.html
+++ b/docs-archive/1.10.10/howto/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/mysql.html
+++ b/docs-archive/1.10.10/howto/connection/mysql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/oracle.html
+++ b/docs-archive/1.10.10/howto/connection/oracle.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/postgres.html
+++ b/docs-archive/1.10.10/howto/connection/postgres.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/connection/ssh.html
+++ b/docs-archive/1.10.10/howto/connection/ssh.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/custom-operator.html
+++ b/docs-archive/1.10.10/howto/custom-operator.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/define_extra_link.html
+++ b/docs-archive/1.10.10/howto/define_extra_link.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/email-config.html
+++ b/docs-archive/1.10.10/howto/email-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/index.html
+++ b/docs-archive/1.10.10/howto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/initialize-database.html
+++ b/docs-archive/1.10.10/howto/initialize-database.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/bash.html
+++ b/docs-archive/1.10.10/howto/operator/bash.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/dingding.html
+++ b/docs-archive/1.10.10/howto/operator/dingding.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/external.html
+++ b/docs-archive/1.10.10/howto/operator/external.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/bigtable.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/cloud_build.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/compute.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/function.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/gcs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/gcs_to_gdrive.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/gcs_to_gdrive.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/natural_language.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/spanner.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/transfer.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/translate-speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/translate.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/video.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.10/howto/operator/gcp/vision.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/index.html
+++ b/docs-archive/1.10.10/howto/operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/papermill.html
+++ b/docs-archive/1.10.10/howto/operator/papermill.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/operator/python.html
+++ b/docs-archive/1.10.10/howto/operator/python.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.10/howto/run-behind-proxy.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/run-with-systemd.html
+++ b/docs-archive/1.10.10/howto/run-with-systemd.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/run-with-upstart.html
+++ b/docs-archive/1.10.10/howto/run-with-upstart.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/secure-connections.html
+++ b/docs-archive/1.10.10/howto/secure-connections.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/set-config.html
+++ b/docs-archive/1.10.10/howto/set-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.10/howto/tracking-user-activity.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/use-alternative-secrets-backend.html
+++ b/docs-archive/1.10.10/howto/use-alternative-secrets-backend.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/use-test-config.html
+++ b/docs-archive/1.10.10/howto/use-test-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/howto/write-logs.html
+++ b/docs-archive/1.10.10/howto/write-logs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/http-routingtable.html
+++ b/docs-archive/1.10.10/http-routingtable.html
@@ -40,7 +40,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/index.html
+++ b/docs-archive/1.10.10/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/installation.html
+++ b/docs-archive/1.10.10/installation.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/integration.html
+++ b/docs-archive/1.10.10/integration.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/kubernetes.html
+++ b/docs-archive/1.10.10/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/license.html
+++ b/docs-archive/1.10.10/license.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/lineage.html
+++ b/docs-archive/1.10.10/lineage.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/macros-ref.html
+++ b/docs-archive/1.10.10/macros-ref.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/metrics.html
+++ b/docs-archive/1.10.10/metrics.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/plugins.html
+++ b/docs-archive/1.10.10/plugins.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/privacy_notice.html
+++ b/docs-archive/1.10.10/privacy_notice.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/profiling.html
+++ b/docs-archive/1.10.10/profiling.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/project.html
+++ b/docs-archive/1.10.10/project.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/py-modindex.html
+++ b/docs-archive/1.10.10/py-modindex.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/rest-api-ref.html
+++ b/docs-archive/1.10.10/rest-api-ref.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/scheduler.html
+++ b/docs-archive/1.10.10/scheduler.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/search.html
+++ b/docs-archive/1.10.10/search.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/security.html
+++ b/docs-archive/1.10.10/security.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/start.html
+++ b/docs-archive/1.10.10/start.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/timezone.html
+++ b/docs-archive/1.10.10/timezone.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/tutorial.html
+++ b/docs-archive/1.10.10/tutorial.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/ui.html
+++ b/docs-archive/1.10.10/ui.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.10/usage-cli.html
+++ b/docs-archive/1.10.10/usage-cli.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/executors/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/gdrive_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/gdrive_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/docker_swarm_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/docker_swarm_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/druid_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/jira_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/secrets/aws_secrets_manager/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/secrets/aws_secrets_manager/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/secrets/aws_systems_manager/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/secrets/aws_systems_manager/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/secrets/gcp_secrets_manager/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/secrets/gcp_secrets_manager/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/secrets/hashicorp_vault/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/secrets/hashicorp_vault/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/secrets/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/secrets/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/exceptions/index.html
+++ b/docs-archive/1.10.11/_api/airflow/exceptions/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/base_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/celery_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/dask_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/debug_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/debug_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/kubernetes_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/local_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/executors/sequential_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/S3_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/base_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/dbapi_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/docker_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/druid_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/hdfs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/hive_hooks/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/http_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/jdbc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/mssql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/mysql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/oracle_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/pig_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/postgres_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/presto_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/samba_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/slack_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/sqlite_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/webhdfs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.11/_api/airflow/hooks/zendesk_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/base/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/baseoperator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/chart/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/connection/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/crypto/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/dag/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/dagbag/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/dagcode/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/dagcode/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/dagpickle/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/dagrun/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/errors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/knownevent/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/kubernetes/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/log/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/pool/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/renderedtifields/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/renderedtifields/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/serialized_dag/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/skipmixin/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/slamiss/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/taskfail/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/taskinstance/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/taskreschedule/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/user/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/variable/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.11/_api/airflow/models/xcom/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/bash_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/branch_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/dagrun_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/docker_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/druid_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/dummy_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/email_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/generic_transfer/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/hive_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/hive_stats_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/hive_to_druid/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/hive_to_mysql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/http_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/jdbc_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/latest_only_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/mssql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/mssql_to_hive/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/mysql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/mysql_to_hive/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/oracle_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/papermill_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/pig_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/postgres_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/presto_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/presto_to_mysql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/python_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/sensors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/slack_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/sql/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/sql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/sql_branch_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/sql_branch_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/sqlite_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/operators/subdag_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/secrets/base_secrets/index.html
+++ b/docs-archive/1.10.11/_api/airflow/secrets/base_secrets/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/secrets/environment_variables/index.html
+++ b/docs-archive/1.10.11/_api/airflow/secrets/environment_variables/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/secrets/index.html
+++ b/docs-archive/1.10.11/_api/airflow/secrets/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/secrets/local_filesystem/index.html
+++ b/docs-archive/1.10.11/_api/airflow/secrets/local_filesystem/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/secrets/metastore/index.html
+++ b/docs-archive/1.10.11/_api/airflow/secrets/metastore/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/base_sensor_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/external_task_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/hdfs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/http_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/s3_key_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/sql_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/time_delta_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/time_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.11/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_api/index.html
+++ b/docs-archive/1.10.11/_api/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.11/_modules/airflow/configuration.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/executors.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/executors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/executors/mesos_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/emr_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/fs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gdrive_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/gdrive_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/imap_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/jira_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/redis_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/segment_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/databricks_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/dingding_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/docker_swarm_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/docker_swarm_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/druid_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/dynamodb_to_s3.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/dynamodb_to_s3.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/ecs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/jira_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/qubole_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sftp_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/ssh_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/vertica_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/operators/winrm_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/secrets/aws_secrets_manager.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/secrets/aws_secrets_manager.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/secrets/aws_systems_manager.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/secrets/aws_systems_manager.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/secrets/gcp_secrets_manager.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/secrets/gcp_secrets_manager.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/secrets/hashicorp_vault.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/secrets/hashicorp_vault.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/file_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/python_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/example_bash_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/example_external_task_marker_dag.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/example_external_task_marker_dag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/example_latest_only_with_trigger.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/example_latest_only_with_trigger.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/example_python_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/example_subdag_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/example_subdag_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/subdags/subdag.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/subdags/subdag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/example_dags/tutorial.html
+++ b/docs-archive/1.10.11/_modules/airflow/example_dags/tutorial.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.11/_modules/airflow/exceptions.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/base_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/celery_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/dask_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/debug_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/debug_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/kubernetes_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/local_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.11/_modules/airflow/executors/sequential_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/S3_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/base_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/dbapi_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/docker_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/druid_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/hdfs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/hive_hooks.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/http_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/jdbc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/mssql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/mysql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/oracle_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/pig_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/postgres_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/presto_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/samba_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/slack_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/sqlite_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/webhdfs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.11/_modules/airflow/hooks/zendesk_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/macros.html
+++ b/docs-archive/1.10.11/_modules/airflow/macros.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.11/_modules/airflow/macros/hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models.html
+++ b/docs-archive/1.10.11/_modules/airflow/models.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/base.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/baseoperator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/chart.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/connection.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/crypto.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/dag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/dagbag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/dagcode.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/dagcode.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/dagpickle.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/dagrun.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/errors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/knownevent.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/kubernetes.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/log.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/pool.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/renderedtifields.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/renderedtifields.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/serialized_dag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/skipmixin.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/slamiss.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/taskfail.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/taskinstance.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/taskreschedule.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/user.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/variable.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.11/_modules/airflow/models/xcom.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/bash_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/branch_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/dagrun_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/docker_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/druid_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/dummy_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/email_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/generic_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/hive_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/hive_stats_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/hive_to_druid.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/hive_to_mysql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/hive_to_samba_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/http_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/jdbc_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/latest_only_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/mssql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/mssql_to_hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/mysql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/mysql_to_hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/oracle_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/papermill_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/pig_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/postgres_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/presto_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/presto_to_mysql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/python_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/s3_file_transform_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/s3_to_hive_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/sensors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/slack_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/sql.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/sql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/sql_branch_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/sql_branch_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/sqlite_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/operators/subdag_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/secrets.html
+++ b/docs-archive/1.10.11/_modules/airflow/secrets.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/secrets/base_secrets.html
+++ b/docs-archive/1.10.11/_modules/airflow/secrets/base_secrets.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/secrets/environment_variables.html
+++ b/docs-archive/1.10.11/_modules/airflow/secrets/environment_variables.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/secrets/local_filesystem.html
+++ b/docs-archive/1.10.11/_modules/airflow/secrets/local_filesystem.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/secrets/metastore.html
+++ b/docs-archive/1.10.11/_modules/airflow/secrets/metastore.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/base_sensor_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/external_task_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/hdfs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/hive_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/http_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/s3_key_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/sql_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/time_delta_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/time_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.11/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/_modules/index.html
+++ b/docs-archive/1.10.11/_modules/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/best-practices.html
+++ b/docs-archive/1.10.11/best-practices.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/changelog.html
+++ b/docs-archive/1.10.11/changelog.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/cli-ref.html
+++ b/docs-archive/1.10.11/cli-ref.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/concepts.html
+++ b/docs-archive/1.10.11/concepts.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/configurations-ref.html
+++ b/docs-archive/1.10.11/configurations-ref.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/dag-run.html
+++ b/docs-archive/1.10.11/dag-run.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/dag-serialization.html
+++ b/docs-archive/1.10.11/dag-serialization.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/errors.html
+++ b/docs-archive/1.10.11/errors.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/celery.html
+++ b/docs-archive/1.10.11/executor/celery.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/dask.html
+++ b/docs-archive/1.10.11/executor/dask.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/debug.html
+++ b/docs-archive/1.10.11/executor/debug.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/index.html
+++ b/docs-archive/1.10.11/executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/kubernetes.html
+++ b/docs-archive/1.10.11/executor/kubernetes.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/local.html
+++ b/docs-archive/1.10.11/executor/local.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/mesos.html
+++ b/docs-archive/1.10.11/executor/mesos.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/executor/sequential.html
+++ b/docs-archive/1.10.11/executor/sequential.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/faq.html
+++ b/docs-archive/1.10.11/faq.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/genindex.html
+++ b/docs-archive/1.10.11/genindex.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/check-health.html
+++ b/docs-archive/1.10.11/howto/check-health.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/aws.html
+++ b/docs-archive/1.10.11/howto/connection/aws.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/gcp.html
+++ b/docs-archive/1.10.11/howto/connection/gcp.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.11/howto/connection/gcp_sql.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/grpc.html
+++ b/docs-archive/1.10.11/howto/connection/grpc.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/index.html
+++ b/docs-archive/1.10.11/howto/connection/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/mysql.html
+++ b/docs-archive/1.10.11/howto/connection/mysql.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/oracle.html
+++ b/docs-archive/1.10.11/howto/connection/oracle.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/postgres.html
+++ b/docs-archive/1.10.11/howto/connection/postgres.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/connection/ssh.html
+++ b/docs-archive/1.10.11/howto/connection/ssh.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/custom-operator.html
+++ b/docs-archive/1.10.11/howto/custom-operator.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/customize-state-colors-ui.html
+++ b/docs-archive/1.10.11/howto/customize-state-colors-ui.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/define_extra_link.html
+++ b/docs-archive/1.10.11/howto/define_extra_link.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/email-config.html
+++ b/docs-archive/1.10.11/howto/email-config.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/index.html
+++ b/docs-archive/1.10.11/howto/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/initialize-database.html
+++ b/docs-archive/1.10.11/howto/initialize-database.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/bash.html
+++ b/docs-archive/1.10.11/howto/operator/bash.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/dingding.html
+++ b/docs-archive/1.10.11/howto/operator/dingding.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/external.html
+++ b/docs-archive/1.10.11/howto/operator/external.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/bigtable.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/cloud_build.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/compute.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/function.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/gcs.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/gcs_to_gdrive.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/gcs_to_gdrive.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/natural_language.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/spanner.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/speech.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/sql.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/transfer.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/translate-speech.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/translate.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/video.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.11/howto/operator/gcp/vision.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/index.html
+++ b/docs-archive/1.10.11/howto/operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/papermill.html
+++ b/docs-archive/1.10.11/howto/operator/papermill.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/operator/python.html
+++ b/docs-archive/1.10.11/howto/operator/python.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.11/howto/run-behind-proxy.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/run-with-systemd.html
+++ b/docs-archive/1.10.11/howto/run-with-systemd.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/run-with-upstart.html
+++ b/docs-archive/1.10.11/howto/run-with-upstart.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/secure-connections.html
+++ b/docs-archive/1.10.11/howto/secure-connections.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/set-config.html
+++ b/docs-archive/1.10.11/howto/set-config.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.11/howto/tracking-user-activity.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/use-alternative-secrets-backend.html
+++ b/docs-archive/1.10.11/howto/use-alternative-secrets-backend.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/use-test-config.html
+++ b/docs-archive/1.10.11/howto/use-test-config.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/howto/write-logs.html
+++ b/docs-archive/1.10.11/howto/write-logs.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/http-routingtable.html
+++ b/docs-archive/1.10.11/http-routingtable.html
@@ -41,7 +41,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/index.html
+++ b/docs-archive/1.10.11/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/installation.html
+++ b/docs-archive/1.10.11/installation.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/integration.html
+++ b/docs-archive/1.10.11/integration.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/kubernetes.html
+++ b/docs-archive/1.10.11/kubernetes.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/license.html
+++ b/docs-archive/1.10.11/license.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/lineage.html
+++ b/docs-archive/1.10.11/lineage.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/macros-ref.html
+++ b/docs-archive/1.10.11/macros-ref.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/metrics.html
+++ b/docs-archive/1.10.11/metrics.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/plugins.html
+++ b/docs-archive/1.10.11/plugins.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/privacy_notice.html
+++ b/docs-archive/1.10.11/privacy_notice.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/profiling.html
+++ b/docs-archive/1.10.11/profiling.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/project.html
+++ b/docs-archive/1.10.11/project.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/py-modindex.html
+++ b/docs-archive/1.10.11/py-modindex.html
@@ -37,7 +37,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/rest-api-ref.html
+++ b/docs-archive/1.10.11/rest-api-ref.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/scheduler.html
+++ b/docs-archive/1.10.11/scheduler.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/search.html
+++ b/docs-archive/1.10.11/search.html
@@ -37,7 +37,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/security.html
+++ b/docs-archive/1.10.11/security.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/start.html
+++ b/docs-archive/1.10.11/start.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/timezone.html
+++ b/docs-archive/1.10.11/timezone.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/tutorial.html
+++ b/docs-archive/1.10.11/tutorial.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/ui.html
+++ b/docs-archive/1.10.11/ui.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.11/usage-cli.html
+++ b/docs-archive/1.10.11/usage-cli.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/gdrive_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/gdrive_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/docker_swarm_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/docker_swarm_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/druid_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/jira_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/secrets/aws_secrets_manager/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/secrets/aws_secrets_manager/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/secrets/aws_systems_manager/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/secrets/aws_systems_manager/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/secrets/gcp_secrets_manager/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/secrets/gcp_secrets_manager/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/secrets/hashicorp_vault/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/secrets/hashicorp_vault/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/secrets/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/secrets/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/exceptions/index.html
+++ b/docs-archive/1.10.12/_api/airflow/exceptions/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/base_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/celery_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/dask_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/debug_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/debug_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/kubernetes_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/local_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/executors/sequential_executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/S3_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/base_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/dbapi_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/docker_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/druid_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/hdfs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/hive_hooks/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/http_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/jdbc_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/mssql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/mysql_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/oracle_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/pig_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/postgres_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/presto_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/samba_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/slack_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/sqlite_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/webhdfs_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.12/_api/airflow/hooks/zendesk_hook/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/base/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/baseoperator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/chart/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/connection/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/crypto/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/dag/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/dagbag/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/dagcode/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/dagcode/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/dagpickle/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/dagrun/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/errors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/knownevent/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/kubernetes/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/log/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/pool/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/renderedtifields/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/renderedtifields/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/serialized_dag/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/skipmixin/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/slamiss/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/taskfail/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/taskinstance/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/taskreschedule/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/user/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/variable/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.12/_api/airflow/models/xcom/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/bash_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/branch_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/dagrun_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/docker_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/druid_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/dummy_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/email_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/generic_transfer/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/hive_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/hive_stats_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/hive_to_druid/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/hive_to_mysql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/http_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/jdbc_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/latest_only_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/mssql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/mssql_to_hive/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/mysql_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/mysql_to_hive/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/oracle_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/papermill_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/pig_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/postgres_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/presto_check_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/presto_to_mysql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/python_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/sensors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/slack_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/sql/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/sql/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/sql_branch_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/sql_branch_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/sqlite_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/operators/subdag_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/secrets/base_secrets/index.html
+++ b/docs-archive/1.10.12/_api/airflow/secrets/base_secrets/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/secrets/environment_variables/index.html
+++ b/docs-archive/1.10.12/_api/airflow/secrets/environment_variables/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/secrets/index.html
+++ b/docs-archive/1.10.12/_api/airflow/secrets/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/secrets/local_filesystem/index.html
+++ b/docs-archive/1.10.12/_api/airflow/secrets/local_filesystem/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/secrets/metastore/index.html
+++ b/docs-archive/1.10.12/_api/airflow/secrets/metastore/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/base_sensor_operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/date_time_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/date_time_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/external_task_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/hdfs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/http_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/s3_key_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/sql_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/time_delta_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/time_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.12/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_api/index.html
+++ b/docs-archive/1.10.12/_api/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.12/_modules/airflow/configuration.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/emr_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/fs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gdrive_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/gdrive_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/imap_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/jira_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/redis_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/segment_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/databricks_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/dingding_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/docker_swarm_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/docker_swarm_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/druid_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/dynamodb_to_s3.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/dynamodb_to_s3.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/ecs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/jira_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/qubole_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sftp_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/ssh_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/vertica_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/operators/winrm_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/secrets/aws_secrets_manager.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/secrets/aws_secrets_manager.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/secrets/aws_systems_manager.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/secrets/aws_systems_manager.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/secrets/gcp_secrets_manager.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/secrets/gcp_secrets_manager.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/secrets/hashicorp_vault.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/secrets/hashicorp_vault.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/file_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/python_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/example_bash_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/example_external_task_marker_dag.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/example_external_task_marker_dag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/example_latest_only_with_trigger.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/example_latest_only_with_trigger.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/example_python_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/example_subdag_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/example_subdag_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/subdags/subdag.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/subdags/subdag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/example_dags/tutorial.html
+++ b/docs-archive/1.10.12/_modules/airflow/example_dags/tutorial.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.12/_modules/airflow/exceptions.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/base_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/celery_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/dask_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/debug_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/debug_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/kubernetes_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/local_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.12/_modules/airflow/executors/sequential_executor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/S3_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/base_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/dbapi_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/docker_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/druid_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/hdfs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/hive_hooks.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/http_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/jdbc_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/mssql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/mysql_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/oracle_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/pig_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/postgres_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/presto_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/samba_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/slack_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/sqlite_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/webhdfs_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.12/_modules/airflow/hooks/zendesk_hook.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/macros.html
+++ b/docs-archive/1.10.12/_modules/airflow/macros.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.12/_modules/airflow/macros/hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models.html
+++ b/docs-archive/1.10.12/_modules/airflow/models.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/base.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/baseoperator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/chart.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/connection.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/crypto.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/dag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/dagbag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/dagcode.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/dagcode.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/dagpickle.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/dagrun.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/errors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/knownevent.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/kubernetes.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/log.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/pool.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/renderedtifields.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/renderedtifields.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/serialized_dag.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/skipmixin.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/slamiss.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/taskfail.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/taskinstance.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/taskreschedule.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/user.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/variable.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.12/_modules/airflow/models/xcom.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/bash_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/branch_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/dagrun_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/docker_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/druid_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/dummy_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/email_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/generic_transfer.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/hive_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/hive_stats_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/hive_to_druid.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/hive_to_mysql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/hive_to_samba_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/http_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/jdbc_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/latest_only_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/mssql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/mssql_to_hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/mysql_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/mysql_to_hive.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/oracle_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/papermill_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/pig_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/postgres_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/presto_check_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/presto_to_mysql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/python_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/s3_file_transform_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/s3_to_hive_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/sensors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/slack_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/sql.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/sql.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/sql_branch_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/sql_branch_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/sqlite_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/operators/subdag_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/secrets.html
+++ b/docs-archive/1.10.12/_modules/airflow/secrets.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/secrets/base_secrets.html
+++ b/docs-archive/1.10.12/_modules/airflow/secrets/base_secrets.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/secrets/environment_variables.html
+++ b/docs-archive/1.10.12/_modules/airflow/secrets/environment_variables.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/secrets/local_filesystem.html
+++ b/docs-archive/1.10.12/_modules/airflow/secrets/local_filesystem.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/secrets/metastore.html
+++ b/docs-archive/1.10.12/_modules/airflow/secrets/metastore.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/base_sensor_operator.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/date_time_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/date_time_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/external_task_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/hdfs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/hive_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/http_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/s3_key_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/sql_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/time_delta_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/time_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.12/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/_modules/index.html
+++ b/docs-archive/1.10.12/_modules/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/best-practices.html
+++ b/docs-archive/1.10.12/best-practices.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/changelog.html
+++ b/docs-archive/1.10.12/changelog.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/cli-ref.html
+++ b/docs-archive/1.10.12/cli-ref.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/concepts.html
+++ b/docs-archive/1.10.12/concepts.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/configurations-ref.html
+++ b/docs-archive/1.10.12/configurations-ref.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/dag-run.html
+++ b/docs-archive/1.10.12/dag-run.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/dag-serialization.html
+++ b/docs-archive/1.10.12/dag-serialization.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/errors.html
+++ b/docs-archive/1.10.12/errors.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/celery.html
+++ b/docs-archive/1.10.12/executor/celery.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/dask.html
+++ b/docs-archive/1.10.12/executor/dask.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/debug.html
+++ b/docs-archive/1.10.12/executor/debug.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/index.html
+++ b/docs-archive/1.10.12/executor/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/kubernetes.html
+++ b/docs-archive/1.10.12/executor/kubernetes.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/local.html
+++ b/docs-archive/1.10.12/executor/local.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/mesos.html
+++ b/docs-archive/1.10.12/executor/mesos.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/executor/sequential.html
+++ b/docs-archive/1.10.12/executor/sequential.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/faq.html
+++ b/docs-archive/1.10.12/faq.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/genindex.html
+++ b/docs-archive/1.10.12/genindex.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/check-health.html
+++ b/docs-archive/1.10.12/howto/check-health.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/aws.html
+++ b/docs-archive/1.10.12/howto/connection/aws.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/gcp.html
+++ b/docs-archive/1.10.12/howto/connection/gcp.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.12/howto/connection/gcp_sql.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/grpc.html
+++ b/docs-archive/1.10.12/howto/connection/grpc.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/index.html
+++ b/docs-archive/1.10.12/howto/connection/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/mysql.html
+++ b/docs-archive/1.10.12/howto/connection/mysql.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/oracle.html
+++ b/docs-archive/1.10.12/howto/connection/oracle.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/postgres.html
+++ b/docs-archive/1.10.12/howto/connection/postgres.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/connection/ssh.html
+++ b/docs-archive/1.10.12/howto/connection/ssh.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/custom-operator.html
+++ b/docs-archive/1.10.12/howto/custom-operator.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/customize-state-colors-ui.html
+++ b/docs-archive/1.10.12/howto/customize-state-colors-ui.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/define_extra_link.html
+++ b/docs-archive/1.10.12/howto/define_extra_link.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/email-config.html
+++ b/docs-archive/1.10.12/howto/email-config.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/index.html
+++ b/docs-archive/1.10.12/howto/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/initialize-database.html
+++ b/docs-archive/1.10.12/howto/initialize-database.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/bash.html
+++ b/docs-archive/1.10.12/howto/operator/bash.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/dingding.html
+++ b/docs-archive/1.10.12/howto/operator/dingding.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/external.html
+++ b/docs-archive/1.10.12/howto/operator/external.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/bigtable.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/cloud_build.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/compute.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/function.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/gcs.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/gcs_to_gdrive.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/gcs_to_gdrive.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/natural_language.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/spanner.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/speech.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/sql.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/transfer.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/translate-speech.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/translate.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/video.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.12/howto/operator/gcp/vision.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/index.html
+++ b/docs-archive/1.10.12/howto/operator/index.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/papermill.html
+++ b/docs-archive/1.10.12/howto/operator/papermill.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/operator/python.html
+++ b/docs-archive/1.10.12/howto/operator/python.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.12/howto/run-behind-proxy.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/run-with-systemd.html
+++ b/docs-archive/1.10.12/howto/run-with-systemd.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/run-with-upstart.html
+++ b/docs-archive/1.10.12/howto/run-with-upstart.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/secure-connections.html
+++ b/docs-archive/1.10.12/howto/secure-connections.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/set-config.html
+++ b/docs-archive/1.10.12/howto/set-config.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.12/howto/tracking-user-activity.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/use-alternative-secrets-backend.html
+++ b/docs-archive/1.10.12/howto/use-alternative-secrets-backend.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/use-test-config.html
+++ b/docs-archive/1.10.12/howto/use-test-config.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/howto/write-logs.html
+++ b/docs-archive/1.10.12/howto/write-logs.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/http-routingtable.html
+++ b/docs-archive/1.10.12/http-routingtable.html
@@ -41,7 +41,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/index.html
+++ b/docs-archive/1.10.12/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/installation.html
+++ b/docs-archive/1.10.12/installation.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/integration.html
+++ b/docs-archive/1.10.12/integration.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/kubernetes.html
+++ b/docs-archive/1.10.12/kubernetes.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/license.html
+++ b/docs-archive/1.10.12/license.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/lineage.html
+++ b/docs-archive/1.10.12/lineage.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/macros-ref.html
+++ b/docs-archive/1.10.12/macros-ref.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/metrics.html
+++ b/docs-archive/1.10.12/metrics.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/plugins.html
+++ b/docs-archive/1.10.12/plugins.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/privacy_notice.html
+++ b/docs-archive/1.10.12/privacy_notice.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/profiling.html
+++ b/docs-archive/1.10.12/profiling.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/project.html
+++ b/docs-archive/1.10.12/project.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/py-modindex.html
+++ b/docs-archive/1.10.12/py-modindex.html
@@ -37,7 +37,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/rest-api-ref.html
+++ b/docs-archive/1.10.12/rest-api-ref.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/scheduler.html
+++ b/docs-archive/1.10.12/scheduler.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/search.html
+++ b/docs-archive/1.10.12/search.html
@@ -37,7 +37,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/security.html
+++ b/docs-archive/1.10.12/security.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/start.html
+++ b/docs-archive/1.10.12/start.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/timezone.html
+++ b/docs-archive/1.10.12/timezone.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/tutorial.html
+++ b/docs-archive/1.10.12/tutorial.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/ui.html
+++ b/docs-archive/1.10.12/ui.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.12/usage-cli.html
+++ b/docs-archive/1.10.12/usage-cli.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.2/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/executors/mesos_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/emr_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/fs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/imap_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/jira_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/redis_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/kubernetes/secret.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/kubernetes/secret.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/databricks_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/druid_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/ecs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_gcs_transfer_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_gcs_transfer_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/jira_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/qubole_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/s3_to_gcs_transfer_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/s3_to_gcs_transfer_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sftp_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/ssh_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/vertica_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/operators/winrm_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/file_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/python_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.2/_modules/airflow/executors/celery_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.2/_modules/airflow/executors/local_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.2/_modules/airflow/executors/sequential_executor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/S3_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/dbapi_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/druid_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/hdfs_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/hive_hooks.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/http_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/mssql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/mysql_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/pig_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/postgres_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/presto_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/samba_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/slack_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/sqlite_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.2/_modules/airflow/hooks/zendesk_hook.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/macros.html
+++ b/docs-archive/1.10.2/_modules/airflow/macros.html
@@ -32,7 +32,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.2/_modules/airflow/macros/hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/models.html
+++ b/docs-archive/1.10.2/_modules/airflow/models.html
@@ -32,7 +32,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/bash_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/dagrun_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/druid_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/dummy_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/email_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/generic_transfer.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/hive_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/hive_stats_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/hive_to_druid.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/hive_to_mysql.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/hive_to_samba_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/http_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/latest_only_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/mssql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/mssql_to_hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/mysql_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/mysql_to_hive.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/pig_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/postgres_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/presto_check_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/presto_to_mysql.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/python_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/s3_file_transform_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/s3_to_hive_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/slack_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/sqlite_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/operators/subdag_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/base_sensor_operator.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/external_task_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/hdfs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/hive_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/http_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/s3_key_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/sql_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/time_delta_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/time_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.2/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -32,7 +32,14 @@
   
   <script src="../../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/_modules/index.html
+++ b/docs-archive/1.10.2/_modules/index.html
@@ -32,7 +32,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/api.html
+++ b/docs-archive/1.10.2/api.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/changelog.html
+++ b/docs-archive/1.10.2/changelog.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/cli.html
+++ b/docs-archive/1.10.2/cli.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/code.html
+++ b/docs-archive/1.10.2/code.html
@@ -33,7 +33,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/concepts.html
+++ b/docs-archive/1.10.2/concepts.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/faq.html
+++ b/docs-archive/1.10.2/faq.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/genindex.html
+++ b/docs-archive/1.10.2/genindex.html
@@ -33,7 +33,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/check-health.html
+++ b/docs-archive/1.10.2/howto/check-health.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/executor/use-celery.html
+++ b/docs-archive/1.10.2/howto/executor/use-celery.html
@@ -34,7 +34,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/executor/use-dask.html
+++ b/docs-archive/1.10.2/howto/executor/use-dask.html
@@ -34,7 +34,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/executor/use-mesos.html
+++ b/docs-archive/1.10.2/howto/executor/use-mesos.html
@@ -34,7 +34,14 @@
   
   <script src="../../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/index.html
+++ b/docs-archive/1.10.2/howto/index.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/initialize-database.html
+++ b/docs-archive/1.10.2/howto/initialize-database.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/manage-connections.html
+++ b/docs-archive/1.10.2/howto/manage-connections.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/operator.html
+++ b/docs-archive/1.10.2/howto/operator.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/run-with-systemd.html
+++ b/docs-archive/1.10.2/howto/run-with-systemd.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/run-with-upstart.html
+++ b/docs-archive/1.10.2/howto/run-with-upstart.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/secure-connections.html
+++ b/docs-archive/1.10.2/howto/secure-connections.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/set-config.html
+++ b/docs-archive/1.10.2/howto/set-config.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/use-test-config.html
+++ b/docs-archive/1.10.2/howto/use-test-config.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/howto/write-logs.html
+++ b/docs-archive/1.10.2/howto/write-logs.html
@@ -34,7 +34,14 @@
   
   <script src="../_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/http-routingtable.html
+++ b/docs-archive/1.10.2/http-routingtable.html
@@ -39,7 +39,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/index.html
+++ b/docs-archive/1.10.2/index.html
@@ -33,7 +33,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/installation.html
+++ b/docs-archive/1.10.2/installation.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/integration.html
+++ b/docs-archive/1.10.2/integration.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/kubernetes.html
+++ b/docs-archive/1.10.2/kubernetes.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/license.html
+++ b/docs-archive/1.10.2/license.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/lineage.html
+++ b/docs-archive/1.10.2/lineage.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/metrics.html
+++ b/docs-archive/1.10.2/metrics.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/plugins.html
+++ b/docs-archive/1.10.2/plugins.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/profiling.html
+++ b/docs-archive/1.10.2/profiling.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/project.html
+++ b/docs-archive/1.10.2/project.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/py-modindex.html
+++ b/docs-archive/1.10.2/py-modindex.html
@@ -35,7 +35,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/scheduler.html
+++ b/docs-archive/1.10.2/scheduler.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/search.html
+++ b/docs-archive/1.10.2/search.html
@@ -32,7 +32,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/security.html
+++ b/docs-archive/1.10.2/security.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/start.html
+++ b/docs-archive/1.10.2/start.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/timezone.html
+++ b/docs-archive/1.10.2/timezone.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/tutorial.html
+++ b/docs-archive/1.10.2/tutorial.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.2/ui.html
+++ b/docs-archive/1.10.2/ui.html
@@ -34,7 +34,14 @@
   
   <script src="_static/js/modernizr.min.js"></script>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/executors/index.html
@@ -116,7 +116,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/druid_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/jira_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/executors/base_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/executors/celery_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/executors/dask_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.3/_api/airflow/executors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/executors/local_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/executors/sequential_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/S3_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/base_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/dbapi_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/docker_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/druid_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/hdfs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/hive_hooks/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/http_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/jdbc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/mssql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/mysql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/oracle_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/pig_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/postgres_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/presto_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/samba_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/slack_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/sqlite_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/webhdfs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.3/_api/airflow/hooks/zendesk_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/base/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/connection/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/dagpickle/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/errors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/kubernetes/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/log/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/skipmixin/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/slamiss/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/taskfail/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.3/_api/airflow/models/taskreschedule/index.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/bash_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/dagrun_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/docker_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/druid_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/dummy_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/email_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/generic_transfer/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/hive_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/hive_stats_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/hive_to_druid/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/hive_to_mysql/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/http_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/jdbc_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/latest_only_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/mssql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/mssql_to_hive/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/mysql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/mysql_to_hive/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/oracle_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/pig_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/postgres_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/presto_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/presto_to_mysql/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/python_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/sensors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/slack_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/sqlite_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/operators/subdag_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/base_sensor_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/external_task_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/hdfs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/http_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/s3_key_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/sql_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/time_delta_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/time_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.3/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_api/index.html
+++ b/docs-archive/1.10.3/_api/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/executors/mesos_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/emr_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/fs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/imap_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/jira_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/redis_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/segment_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/databricks_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/dingding_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/druid_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/ecs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/jira_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/qubole_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sftp_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/ssh_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/vertica_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/operators/winrm_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/file_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/python_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/dag/base_dag.html
+++ b/docs-archive/1.10.3/_modules/airflow/dag/base_dag.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/example_dags/example_bash_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/example_dags/example_python_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.3/_modules/airflow/exceptions.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/executors.html
+++ b/docs-archive/1.10.3/_modules/airflow/executors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/executors/base_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/executors/celery_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/executors/dask_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/executors/local_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.3/_modules/airflow/executors/sequential_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/S3_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/base_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/dbapi_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/docker_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/druid_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/hdfs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/hive_hooks.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/http_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/jdbc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/mssql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/mysql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/oracle_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/pig_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/postgres_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/presto_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/samba_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/slack_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/sqlite_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/webhdfs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.3/_modules/airflow/hooks/zendesk_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/lineage.html
+++ b/docs-archive/1.10.3/_modules/airflow/lineage.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/macros.html
+++ b/docs-archive/1.10.3/_modules/airflow/macros.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.3/_modules/airflow/macros/hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models.html
+++ b/docs-archive/1.10.3/_modules/airflow/models.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/base.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/connection.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/dagpickle.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/errors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/kubernetes.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/log.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/skipmixin.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/slamiss.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/taskfail.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.3/_modules/airflow/models/taskreschedule.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/bash_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/dagrun_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/docker_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/druid_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/dummy_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/email_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/generic_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/hive_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/hive_stats_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/hive_to_druid.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/hive_to_mysql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/hive_to_samba_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/http_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/jdbc_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/latest_only_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/mssql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/mssql_to_hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/mysql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/mysql_to_hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/oracle_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/pig_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/postgres_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/presto_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/presto_to_mysql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/python_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/s3_file_transform_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/s3_to_hive_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/sensors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/slack_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/sqlite_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/operators/subdag_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/base_sensor_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/external_task_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/hdfs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/hive_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/http_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/s3_key_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/sql_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/time_delta_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/time_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.3/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/ti_deps/dep_context.html
+++ b/docs-archive/1.10.3/_modules/airflow/ti_deps/dep_context.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/ti_deps/deps/not_in_retry_period_dep.html
+++ b/docs-archive/1.10.3/_modules/airflow/ti_deps/deps/not_in_retry_period_dep.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/ti_deps/deps/prev_dagrun_dep.html
+++ b/docs-archive/1.10.3/_modules/airflow/ti_deps/deps/prev_dagrun_dep.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/ti_deps/deps/trigger_rule_dep.html
+++ b/docs-archive/1.10.3/_modules/airflow/ti_deps/deps/trigger_rule_dep.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/dag_processing.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/dag_processing.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/dates.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/dates.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/db.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/db.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/decorators.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/decorators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/email.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/email.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/helpers.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/helpers.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/log/logging_mixin.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/net.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/net.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/operator_resources.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/operator_resources.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/sqlalchemy.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/sqlalchemy.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/state.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/state.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/timeout.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/timeout.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/trigger_rule.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/trigger_rule.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/airflow/utils/weight_rule.html
+++ b/docs-archive/1.10.3/_modules/airflow/utils/weight_rule.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/_modules/index.html
+++ b/docs-archive/1.10.3/_modules/index.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/api.html
+++ b/docs-archive/1.10.3/api.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/changelog.html
+++ b/docs-archive/1.10.3/changelog.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/cli.html
+++ b/docs-archive/1.10.3/cli.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/concepts.html
+++ b/docs-archive/1.10.3/concepts.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/faq.html
+++ b/docs-archive/1.10.3/faq.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/genindex.html
+++ b/docs-archive/1.10.3/genindex.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/check-health.html
+++ b/docs-archive/1.10.3/howto/check-health.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/aws.html
+++ b/docs-archive/1.10.3/howto/connection/aws.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/gcp.html
+++ b/docs-archive/1.10.3/howto/connection/gcp.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.3/howto/connection/gcp_sql.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/index.html
+++ b/docs-archive/1.10.3/howto/connection/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/mysql.html
+++ b/docs-archive/1.10.3/howto/connection/mysql.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/oracle.html
+++ b/docs-archive/1.10.3/howto/connection/oracle.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/postgres.html
+++ b/docs-archive/1.10.3/howto/connection/postgres.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/connection/ssh.html
+++ b/docs-archive/1.10.3/howto/connection/ssh.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/executor/use-celery.html
+++ b/docs-archive/1.10.3/howto/executor/use-celery.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/executor/use-dask.html
+++ b/docs-archive/1.10.3/howto/executor/use-dask.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/executor/use-mesos.html
+++ b/docs-archive/1.10.3/howto/executor/use-mesos.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/index.html
+++ b/docs-archive/1.10.3/howto/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/initialize-database.html
+++ b/docs-archive/1.10.3/howto/initialize-database.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/bash.html
+++ b/docs-archive/1.10.3/howto/operator/bash.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/dingding.html
+++ b/docs-archive/1.10.3/howto/operator/dingding.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/bigtable.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/compute.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/function.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/gcs.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/natural_language.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/spanner.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/sql.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/transfer.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/translate.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.3/howto/operator/gcp/vision.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/index.html
+++ b/docs-archive/1.10.3/howto/operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/operator/python.html
+++ b/docs-archive/1.10.3/howto/operator/python.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.3/howto/run-behind-proxy.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/run-with-systemd.html
+++ b/docs-archive/1.10.3/howto/run-with-systemd.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/run-with-upstart.html
+++ b/docs-archive/1.10.3/howto/run-with-upstart.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/secure-connections.html
+++ b/docs-archive/1.10.3/howto/secure-connections.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/set-config.html
+++ b/docs-archive/1.10.3/howto/set-config.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/use-test-config.html
+++ b/docs-archive/1.10.3/howto/use-test-config.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/howto/write-logs.html
+++ b/docs-archive/1.10.3/howto/write-logs.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/http-routingtable.html
+++ b/docs-archive/1.10.3/http-routingtable.html
@@ -125,7 +125,14 @@
     </script>
 
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/index.html
+++ b/docs-archive/1.10.3/index.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/installation.html
+++ b/docs-archive/1.10.3/installation.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/integration.html
+++ b/docs-archive/1.10.3/integration.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/kubernetes.html
+++ b/docs-archive/1.10.3/kubernetes.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/license.html
+++ b/docs-archive/1.10.3/license.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/lineage.html
+++ b/docs-archive/1.10.3/lineage.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/macros.html
+++ b/docs-archive/1.10.3/macros.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/metrics.html
+++ b/docs-archive/1.10.3/metrics.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/plugins.html
+++ b/docs-archive/1.10.3/plugins.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/profiling.html
+++ b/docs-archive/1.10.3/profiling.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/project.html
+++ b/docs-archive/1.10.3/project.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/py-modindex.html
+++ b/docs-archive/1.10.3/py-modindex.html
@@ -121,7 +121,14 @@
 
 
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/scheduler.html
+++ b/docs-archive/1.10.3/scheduler.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/search.html
+++ b/docs-archive/1.10.3/search.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/security.html
+++ b/docs-archive/1.10.3/security.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/start.html
+++ b/docs-archive/1.10.3/start.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/timezone.html
+++ b/docs-archive/1.10.3/timezone.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/tutorial.html
+++ b/docs-archive/1.10.3/tutorial.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.3/ui.html
+++ b/docs-archive/1.10.3/ui.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/executors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/druid_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/jira_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/executors/base_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/executors/celery_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/executors/dask_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.4/_api/airflow/executors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/executors/local_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/executors/sequential_executor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/S3_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/base_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/dbapi_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/docker_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/druid_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/hdfs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/hive_hooks/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/http_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/jdbc_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/mssql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/mysql_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/oracle_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/pig_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/postgres_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/presto_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/samba_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/slack_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/sqlite_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/webhdfs_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.4/_api/airflow/hooks/zendesk_hook/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/base/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/baseoperator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/chart/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/connection/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/crypto/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/dag/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/dagbag/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/dagpickle/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/dagrun/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/errors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/knownevent/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/kubernetes/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/log/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/pool/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/skipmixin/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/slamiss/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/taskfail/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/taskinstance/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/taskreschedule/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/user/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/variable/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.4/_api/airflow/models/xcom/index.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/bash_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/branch_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/dagrun_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/docker_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/druid_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/dummy_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/email_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/generic_transfer/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/hive_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/hive_stats_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/hive_to_druid/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/hive_to_mysql/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/http_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/jdbc_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/latest_only_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/mssql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/mssql_to_hive/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/mysql_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/mysql_to_hive/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/oracle_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/pig_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/postgres_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/presto_check_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/presto_to_mysql/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/python_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/sensors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/slack_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/sqlite_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/operators/subdag_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/base_sensor_operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/external_task_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/hdfs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/http_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/s3_key_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/sql_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/time_delta_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/time_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.4/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_api/index.html
+++ b/docs-archive/1.10.4/_api/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/executors/mesos_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/emr_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/fs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/imap_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/jira_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/redis_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/segment_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/databricks_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/dingding_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/druid_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/ecs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/jira_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/qubole_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sftp_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/ssh_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/vertica_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/operators/winrm_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/file_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/python_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/example_dags/example_bash_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/example_dags/example_python_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.4/_modules/airflow/exceptions.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/executors.html
+++ b/docs-archive/1.10.4/_modules/airflow/executors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/executors/base_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/executors/celery_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/executors/dask_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/executors/local_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.4/_modules/airflow/executors/sequential_executor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/S3_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/base_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/dbapi_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/docker_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/druid_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/hdfs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/hive_hooks.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/http_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/jdbc_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/mssql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/mysql_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/oracle_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/pig_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/postgres_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/presto_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/samba_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/slack_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/sqlite_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/webhdfs_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.4/_modules/airflow/hooks/zendesk_hook.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/macros.html
+++ b/docs-archive/1.10.4/_modules/airflow/macros.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.4/_modules/airflow/macros/hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models.html
+++ b/docs-archive/1.10.4/_modules/airflow/models.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/base.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/baseoperator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/chart.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/connection.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/crypto.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/dag.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/dagbag.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/dagpickle.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/dagrun.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/errors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/knownevent.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/kubernetes.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/log.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/pool.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/skipmixin.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/slamiss.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/taskfail.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/taskinstance.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/taskreschedule.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/user.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/variable.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.4/_modules/airflow/models/xcom.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/bash_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/branch_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/dagrun_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/docker_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/druid_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/dummy_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/email_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/generic_transfer.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/hive_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/hive_stats_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/hive_to_druid.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/hive_to_mysql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/hive_to_samba_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/http_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/jdbc_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/latest_only_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/mssql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/mssql_to_hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/mysql_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/mysql_to_hive.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/oracle_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/pig_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/postgres_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/presto_check_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/presto_to_mysql.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/python_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/s3_file_transform_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/s3_to_hive_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/sensors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/slack_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/sqlite_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/operators/subdag_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/base_sensor_operator.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/external_task_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/hdfs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/hive_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/http_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/s3_key_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/sql_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/time_delta_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/time_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.4/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.4/_modules/airflow/utils/log/logging_mixin.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/_modules/index.html
+++ b/docs-archive/1.10.4/_modules/index.html
@@ -118,7 +118,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/api.html
+++ b/docs-archive/1.10.4/api.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/changelog.html
+++ b/docs-archive/1.10.4/changelog.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/cli.html
+++ b/docs-archive/1.10.4/cli.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/concepts.html
+++ b/docs-archive/1.10.4/concepts.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/faq.html
+++ b/docs-archive/1.10.4/faq.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/genindex.html
+++ b/docs-archive/1.10.4/genindex.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/check-health.html
+++ b/docs-archive/1.10.4/howto/check-health.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/aws.html
+++ b/docs-archive/1.10.4/howto/connection/aws.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/gcp.html
+++ b/docs-archive/1.10.4/howto/connection/gcp.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.4/howto/connection/gcp_sql.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/grpc.html
+++ b/docs-archive/1.10.4/howto/connection/grpc.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/index.html
+++ b/docs-archive/1.10.4/howto/connection/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/mysql.html
+++ b/docs-archive/1.10.4/howto/connection/mysql.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/oracle.html
+++ b/docs-archive/1.10.4/howto/connection/oracle.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/postgres.html
+++ b/docs-archive/1.10.4/howto/connection/postgres.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/connection/ssh.html
+++ b/docs-archive/1.10.4/howto/connection/ssh.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/define_extra_link.html
+++ b/docs-archive/1.10.4/howto/define_extra_link.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/executor/use-celery.html
+++ b/docs-archive/1.10.4/howto/executor/use-celery.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/executor/use-dask.html
+++ b/docs-archive/1.10.4/howto/executor/use-dask.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/executor/use-mesos.html
+++ b/docs-archive/1.10.4/howto/executor/use-mesos.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/index.html
+++ b/docs-archive/1.10.4/howto/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/initialize-database.html
+++ b/docs-archive/1.10.4/howto/initialize-database.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/bash.html
+++ b/docs-archive/1.10.4/howto/operator/bash.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/dingding.html
+++ b/docs-archive/1.10.4/howto/operator/dingding.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/bigtable.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/cloud_build.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/compute.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/function.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/gcs.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/natural_language.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/spanner.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/speech.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/sql.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/transfer.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/translate-speech.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/translate.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/video.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.4/howto/operator/gcp/vision.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/index.html
+++ b/docs-archive/1.10.4/howto/operator/index.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/operator/python.html
+++ b/docs-archive/1.10.4/howto/operator/python.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.4/howto/run-behind-proxy.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/run-with-systemd.html
+++ b/docs-archive/1.10.4/howto/run-with-systemd.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/run-with-upstart.html
+++ b/docs-archive/1.10.4/howto/run-with-upstart.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/secure-connections.html
+++ b/docs-archive/1.10.4/howto/secure-connections.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/set-config.html
+++ b/docs-archive/1.10.4/howto/set-config.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/use-test-config.html
+++ b/docs-archive/1.10.4/howto/use-test-config.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/howto/write-logs.html
+++ b/docs-archive/1.10.4/howto/write-logs.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/http-routingtable.html
+++ b/docs-archive/1.10.4/http-routingtable.html
@@ -125,7 +125,14 @@
     </script>
 
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/index.html
+++ b/docs-archive/1.10.4/index.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/installation.html
+++ b/docs-archive/1.10.4/installation.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/integration.html
+++ b/docs-archive/1.10.4/integration.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/kubernetes.html
+++ b/docs-archive/1.10.4/kubernetes.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/license.html
+++ b/docs-archive/1.10.4/license.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/lineage.html
+++ b/docs-archive/1.10.4/lineage.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/macros.html
+++ b/docs-archive/1.10.4/macros.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/metrics.html
+++ b/docs-archive/1.10.4/metrics.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/plugins.html
+++ b/docs-archive/1.10.4/plugins.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/profiling.html
+++ b/docs-archive/1.10.4/profiling.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/project.html
+++ b/docs-archive/1.10.4/project.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/py-modindex.html
+++ b/docs-archive/1.10.4/py-modindex.html
@@ -121,7 +121,14 @@
 
 
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/scheduler.html
+++ b/docs-archive/1.10.4/scheduler.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/search.html
+++ b/docs-archive/1.10.4/search.html
@@ -119,7 +119,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/security.html
+++ b/docs-archive/1.10.4/security.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/start.html
+++ b/docs-archive/1.10.4/start.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/timezone.html
+++ b/docs-archive/1.10.4/timezone.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/tutorial.html
+++ b/docs-archive/1.10.4/tutorial.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.4/ui.html
+++ b/docs-archive/1.10.4/ui.html
@@ -120,7 +120,14 @@
     }
   </style>
 
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
 </head>
+
 
 <body class="wy-body-for-nav">
 

--- a/docs-archive/1.10.6/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/druid_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/jira_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/executors/base_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/executors/celery_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/executors/dask_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.6/_api/airflow/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/executors/local_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/executors/sequential_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/S3_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/dbapi_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/docker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/druid_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/hdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/hive_hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/http_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/mssql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/mysql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/oracle_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/pig_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/postgres_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/presto_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/samba_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/slack_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/sqlite_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/webhdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.6/_api/airflow/hooks/zendesk_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/base/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/baseoperator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/chart/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/crypto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/dagbag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/dagpickle/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/dagrun/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/errors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/knownevent/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/kubernetes/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/log/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/pool/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/skipmixin/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/slamiss/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/taskfail/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/taskinstance/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/taskreschedule/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/user/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/variable/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.6/_api/airflow/models/xcom/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/bash_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/branch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/dagrun_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/docker_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/druid_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/dummy_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/email_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/generic_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/hive_stats_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/hive_to_druid/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/hive_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/http_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/latest_only_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/mssql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/mssql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/mysql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/oracle_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/papermill_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/pig_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/postgres_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/presto_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/presto_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/python_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/slack_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/sqlite_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/operators/subdag_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/base_sensor_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/external_task_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/http_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/s3_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/sql_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/time_delta_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/time_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.6/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_api/index.html
+++ b/docs-archive/1.10.6/_api/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.6/_modules/airflow/configuration.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/executors/mesos_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/emr_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/fs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/imap_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/jira_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/redis_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/segment_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/databricks_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/druid_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/ecs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/jira_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/qubole_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/ssh_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/vertica_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/operators/winrm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/file_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/python_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/example_dags/example_bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/example_dags/example_python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.6/_modules/airflow/exceptions.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/executors.html
+++ b/docs-archive/1.10.6/_modules/airflow/executors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/executors/base_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/executors/celery_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/executors/dask_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/executors/local_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.6/_modules/airflow/executors/sequential_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/S3_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/dbapi_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/docker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/druid_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/hdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/hive_hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/http_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/mssql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/mysql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/oracle_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/pig_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/postgres_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/presto_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/samba_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/slack_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/sqlite_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/webhdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.6/_modules/airflow/hooks/zendesk_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/macros.html
+++ b/docs-archive/1.10.6/_modules/airflow/macros.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.6/_modules/airflow/macros/hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models.html
+++ b/docs-archive/1.10.6/_modules/airflow/models.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/base.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/baseoperator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/chart.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/connection.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/crypto.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/dagbag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/dagpickle.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/dagrun.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/errors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/knownevent.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/kubernetes.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/log.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/pool.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/skipmixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/slamiss.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/taskfail.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/taskinstance.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/taskreschedule.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/user.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/variable.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.6/_modules/airflow/models/xcom.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/branch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/dagrun_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/docker_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/druid_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/dummy_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/email_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/generic_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/hive_stats_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/hive_to_druid.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/hive_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/hive_to_samba_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/http_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/latest_only_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/mssql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/mssql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/mysql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/oracle_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/pig_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/postgres_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/presto_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/presto_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/s3_file_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/s3_to_hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/slack_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/sqlite_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/operators/subdag_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/base_sensor_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/external_task_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/http_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/s3_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/sql_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/time_delta_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/time_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.6/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.6/_modules/airflow/utils/log/logging_mixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/_modules/index.html
+++ b/docs-archive/1.10.6/_modules/index.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/api.html
+++ b/docs-archive/1.10.6/api.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/changelog.html
+++ b/docs-archive/1.10.6/changelog.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/cli.html
+++ b/docs-archive/1.10.6/cli.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/concepts.html
+++ b/docs-archive/1.10.6/concepts.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/errors.html
+++ b/docs-archive/1.10.6/errors.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/faq.html
+++ b/docs-archive/1.10.6/faq.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/genindex.html
+++ b/docs-archive/1.10.6/genindex.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/check-health.html
+++ b/docs-archive/1.10.6/howto/check-health.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/cli-completion.html
+++ b/docs-archive/1.10.6/howto/cli-completion.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/aws.html
+++ b/docs-archive/1.10.6/howto/connection/aws.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/gcp.html
+++ b/docs-archive/1.10.6/howto/connection/gcp.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.6/howto/connection/gcp_sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/grpc.html
+++ b/docs-archive/1.10.6/howto/connection/grpc.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/index.html
+++ b/docs-archive/1.10.6/howto/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/mysql.html
+++ b/docs-archive/1.10.6/howto/connection/mysql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/oracle.html
+++ b/docs-archive/1.10.6/howto/connection/oracle.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/postgres.html
+++ b/docs-archive/1.10.6/howto/connection/postgres.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/connection/ssh.html
+++ b/docs-archive/1.10.6/howto/connection/ssh.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/define_extra_link.html
+++ b/docs-archive/1.10.6/howto/define_extra_link.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/executor/use-celery.html
+++ b/docs-archive/1.10.6/howto/executor/use-celery.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/executor/use-dask.html
+++ b/docs-archive/1.10.6/howto/executor/use-dask.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/executor/use-mesos.html
+++ b/docs-archive/1.10.6/howto/executor/use-mesos.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/index.html
+++ b/docs-archive/1.10.6/howto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/initialize-database.html
+++ b/docs-archive/1.10.6/howto/initialize-database.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/bash.html
+++ b/docs-archive/1.10.6/howto/operator/bash.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/dingding.html
+++ b/docs-archive/1.10.6/howto/operator/dingding.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/bigtable.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/cloud_build.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/compute.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/function.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/gcs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/natural_language.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/spanner.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/transfer.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/translate-speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/translate.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/video.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.6/howto/operator/gcp/vision.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/index.html
+++ b/docs-archive/1.10.6/howto/operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/papermill.html
+++ b/docs-archive/1.10.6/howto/operator/papermill.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/operator/python.html
+++ b/docs-archive/1.10.6/howto/operator/python.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.6/howto/run-behind-proxy.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/run-with-systemd.html
+++ b/docs-archive/1.10.6/howto/run-with-systemd.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/run-with-upstart.html
+++ b/docs-archive/1.10.6/howto/run-with-upstart.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/secure-connections.html
+++ b/docs-archive/1.10.6/howto/secure-connections.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/set-config.html
+++ b/docs-archive/1.10.6/howto/set-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.6/howto/tracking-user-activity.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/use-test-config.html
+++ b/docs-archive/1.10.6/howto/use-test-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/howto/write-logs.html
+++ b/docs-archive/1.10.6/howto/write-logs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/http-routingtable.html
+++ b/docs-archive/1.10.6/http-routingtable.html
@@ -40,7 +40,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/index.html
+++ b/docs-archive/1.10.6/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/installation.html
+++ b/docs-archive/1.10.6/installation.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/integration.html
+++ b/docs-archive/1.10.6/integration.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/kubernetes.html
+++ b/docs-archive/1.10.6/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/license.html
+++ b/docs-archive/1.10.6/license.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/lineage.html
+++ b/docs-archive/1.10.6/lineage.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/macros.html
+++ b/docs-archive/1.10.6/macros.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/metrics.html
+++ b/docs-archive/1.10.6/metrics.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/plugins.html
+++ b/docs-archive/1.10.6/plugins.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/privacy_notice.html
+++ b/docs-archive/1.10.6/privacy_notice.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/profiling.html
+++ b/docs-archive/1.10.6/profiling.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/project.html
+++ b/docs-archive/1.10.6/project.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/py-modindex.html
+++ b/docs-archive/1.10.6/py-modindex.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/scheduler.html
+++ b/docs-archive/1.10.6/scheduler.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/search.html
+++ b/docs-archive/1.10.6/search.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/security.html
+++ b/docs-archive/1.10.6/security.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/start.html
+++ b/docs-archive/1.10.6/start.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/timezone.html
+++ b/docs-archive/1.10.6/timezone.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/tutorial.html
+++ b/docs-archive/1.10.6/tutorial.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.6/ui.html
+++ b/docs-archive/1.10.6/ui.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/gdrive_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/gdrive_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/docker_swarm_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/docker_swarm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/druid_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/jira_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/executors/base_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/executors/celery_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/executors/dask_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.7/_api/airflow/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/executors/local_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/executors/sequential_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/S3_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/dbapi_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/docker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/druid_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/hdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/hive_hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/http_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/mssql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/mysql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/oracle_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/pig_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/postgres_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/presto_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/samba_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/slack_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/sqlite_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/webhdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.7/_api/airflow/hooks/zendesk_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/base/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/baseoperator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/chart/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/crypto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/dagbag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/dagpickle/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/dagrun/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/errors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/knownevent/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/kubernetes/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/log/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/pool/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/serialized_dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/skipmixin/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/slamiss/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/taskfail/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/taskinstance/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/taskreschedule/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/user/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/variable/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.7/_api/airflow/models/xcom/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/bash_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/branch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/dagrun_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/docker_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/druid_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/dummy_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/email_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/generic_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/hive_stats_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/hive_to_druid/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/hive_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/http_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/latest_only_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/mssql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/mssql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/mysql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/oracle_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/papermill_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/pig_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/postgres_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/presto_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/presto_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/python_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/slack_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/sqlite_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/operators/subdag_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/base_sensor_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/external_task_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/http_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/s3_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/sql_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/time_delta_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/time_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.7/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_api/index.html
+++ b/docs-archive/1.10.7/_api/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.7/_modules/airflow/configuration.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/executors/mesos_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/emr_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/fs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gdrive_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/gdrive_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/imap_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/jira_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/redis_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/segment_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/databricks_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/docker_swarm_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/docker_swarm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/druid_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/dynamodb_to_s3.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/dynamodb_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/ecs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/jira_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/qubole_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/ssh_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/vertica_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/operators/winrm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/file_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/python_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/example_dags/example_bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/example_dags/example_python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.7/_modules/airflow/exceptions.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/executors.html
+++ b/docs-archive/1.10.7/_modules/airflow/executors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/executors/base_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/executors/celery_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/executors/dask_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/executors/local_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.7/_modules/airflow/executors/sequential_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/S3_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/dbapi_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/docker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/druid_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/hdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/hive_hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/http_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/mssql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/mysql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/oracle_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/pig_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/postgres_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/presto_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/samba_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/slack_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/sqlite_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/webhdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.7/_modules/airflow/hooks/zendesk_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/macros.html
+++ b/docs-archive/1.10.7/_modules/airflow/macros.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.7/_modules/airflow/macros/hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models.html
+++ b/docs-archive/1.10.7/_modules/airflow/models.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/base.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/baseoperator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/chart.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/connection.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/crypto.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/dagbag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/dagpickle.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/dagrun.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/errors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/knownevent.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/kubernetes.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/log.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/pool.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/serialized_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/skipmixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/slamiss.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/taskfail.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/taskinstance.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/taskreschedule.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/user.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/variable.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.7/_modules/airflow/models/xcom.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/branch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/dagrun_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/docker_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/druid_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/dummy_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/email_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/generic_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/hive_stats_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/hive_to_druid.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/hive_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/hive_to_samba_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/http_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/latest_only_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/mssql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/mssql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/mysql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/oracle_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/pig_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/postgres_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/presto_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/presto_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/s3_file_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/s3_to_hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/slack_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/sqlite_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/operators/subdag_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/base_sensor_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/external_task_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/http_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/s3_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/sql_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/time_delta_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/time_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.7/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.7/_modules/airflow/utils/log/logging_mixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/_modules/index.html
+++ b/docs-archive/1.10.7/_modules/index.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/api.html
+++ b/docs-archive/1.10.7/api.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/best-practices.html
+++ b/docs-archive/1.10.7/best-practices.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/changelog.html
+++ b/docs-archive/1.10.7/changelog.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/cli.html
+++ b/docs-archive/1.10.7/cli.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/concepts.html
+++ b/docs-archive/1.10.7/concepts.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/dag-serialization.html
+++ b/docs-archive/1.10.7/dag-serialization.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/errors.html
+++ b/docs-archive/1.10.7/errors.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/executor/celery.html
+++ b/docs-archive/1.10.7/executor/celery.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/executor/dask.html
+++ b/docs-archive/1.10.7/executor/dask.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/executor/index.html
+++ b/docs-archive/1.10.7/executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/executor/kubernetes.html
+++ b/docs-archive/1.10.7/executor/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/executor/mesos.html
+++ b/docs-archive/1.10.7/executor/mesos.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/faq.html
+++ b/docs-archive/1.10.7/faq.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/genindex.html
+++ b/docs-archive/1.10.7/genindex.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/check-health.html
+++ b/docs-archive/1.10.7/howto/check-health.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/cli-completion.html
+++ b/docs-archive/1.10.7/howto/cli-completion.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/aws.html
+++ b/docs-archive/1.10.7/howto/connection/aws.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/gcp.html
+++ b/docs-archive/1.10.7/howto/connection/gcp.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.7/howto/connection/gcp_sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/grpc.html
+++ b/docs-archive/1.10.7/howto/connection/grpc.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/index.html
+++ b/docs-archive/1.10.7/howto/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/mysql.html
+++ b/docs-archive/1.10.7/howto/connection/mysql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/oracle.html
+++ b/docs-archive/1.10.7/howto/connection/oracle.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/postgres.html
+++ b/docs-archive/1.10.7/howto/connection/postgres.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/connection/ssh.html
+++ b/docs-archive/1.10.7/howto/connection/ssh.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/custom-operator.html
+++ b/docs-archive/1.10.7/howto/custom-operator.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/define_extra_link.html
+++ b/docs-archive/1.10.7/howto/define_extra_link.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/index.html
+++ b/docs-archive/1.10.7/howto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/initialize-database.html
+++ b/docs-archive/1.10.7/howto/initialize-database.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/bash.html
+++ b/docs-archive/1.10.7/howto/operator/bash.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/dingding.html
+++ b/docs-archive/1.10.7/howto/operator/dingding.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/bigtable.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/cloud_build.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/compute.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/function.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/gcs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/gcs_to_gdrive.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/gcs_to_gdrive.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/natural_language.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/spanner.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/transfer.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/translate-speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/translate.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/video.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.7/howto/operator/gcp/vision.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/index.html
+++ b/docs-archive/1.10.7/howto/operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/papermill.html
+++ b/docs-archive/1.10.7/howto/operator/papermill.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/operator/python.html
+++ b/docs-archive/1.10.7/howto/operator/python.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.7/howto/run-behind-proxy.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/run-with-systemd.html
+++ b/docs-archive/1.10.7/howto/run-with-systemd.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/run-with-upstart.html
+++ b/docs-archive/1.10.7/howto/run-with-upstart.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/secure-connections.html
+++ b/docs-archive/1.10.7/howto/secure-connections.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/set-config.html
+++ b/docs-archive/1.10.7/howto/set-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.7/howto/tracking-user-activity.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/use-test-config.html
+++ b/docs-archive/1.10.7/howto/use-test-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/howto/write-logs.html
+++ b/docs-archive/1.10.7/howto/write-logs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/http-routingtable.html
+++ b/docs-archive/1.10.7/http-routingtable.html
@@ -40,7 +40,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/index.html
+++ b/docs-archive/1.10.7/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/installation.html
+++ b/docs-archive/1.10.7/installation.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/integration.html
+++ b/docs-archive/1.10.7/integration.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/kubernetes.html
+++ b/docs-archive/1.10.7/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/license.html
+++ b/docs-archive/1.10.7/license.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/lineage.html
+++ b/docs-archive/1.10.7/lineage.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/macros.html
+++ b/docs-archive/1.10.7/macros.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/metrics.html
+++ b/docs-archive/1.10.7/metrics.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/plugins.html
+++ b/docs-archive/1.10.7/plugins.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/privacy_notice.html
+++ b/docs-archive/1.10.7/privacy_notice.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/profiling.html
+++ b/docs-archive/1.10.7/profiling.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/project.html
+++ b/docs-archive/1.10.7/project.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/py-modindex.html
+++ b/docs-archive/1.10.7/py-modindex.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/scheduler.html
+++ b/docs-archive/1.10.7/scheduler.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/search.html
+++ b/docs-archive/1.10.7/search.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/security.html
+++ b/docs-archive/1.10.7/security.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/start.html
+++ b/docs-archive/1.10.7/start.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/timezone.html
+++ b/docs-archive/1.10.7/timezone.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/tutorial.html
+++ b/docs-archive/1.10.7/tutorial.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.7/ui.html
+++ b/docs-archive/1.10.7/ui.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/gdrive_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/gdrive_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/docker_swarm_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/docker_swarm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/druid_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/jira_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/base_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/celery_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/dask_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/debug_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/debug_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/local_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/executors/sequential_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/S3_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/dbapi_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/docker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/druid_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/hdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/hive_hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/http_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/mssql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/mysql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/oracle_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/pig_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/postgres_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/presto_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/samba_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/slack_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/sqlite_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/webhdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.8/_api/airflow/hooks/zendesk_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/base/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/baseoperator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/chart/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/crypto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/dagbag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/dagpickle/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/dagrun/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/errors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/knownevent/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/kubernetes/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/log/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/pool/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/serialized_dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/skipmixin/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/slamiss/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/taskfail/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/taskinstance/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/taskreschedule/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/user/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/variable/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.8/_api/airflow/models/xcom/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/bash_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/branch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/dagrun_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/docker_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/druid_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/dummy_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/email_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/generic_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/hive_stats_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/hive_to_druid/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/hive_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/http_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/latest_only_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/mssql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/mssql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/mysql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/oracle_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/papermill_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/pig_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/postgres_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/presto_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/presto_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/python_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/slack_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/sqlite_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/operators/subdag_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/base_sensor_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/external_task_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/http_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/s3_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/sql_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/time_delta_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/time_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.8/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_api/index.html
+++ b/docs-archive/1.10.8/_api/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.8/_modules/airflow/configuration.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/executors/mesos_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/emr_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/fs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gdrive_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/gdrive_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/imap_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/jira_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/redis_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/segment_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/databricks_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/docker_swarm_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/docker_swarm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/druid_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/dynamodb_to_s3.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/dynamodb_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/ecs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/jira_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/qubole_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/ssh_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/vertica_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/operators/winrm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/file_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/python_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/example_dags/example_bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/example_dags/example_external_task_marker_dag.html
+++ b/docs-archive/1.10.8/_modules/airflow/example_dags/example_external_task_marker_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/example_dags/example_python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/example_dags/tutorial.html
+++ b/docs-archive/1.10.8/_modules/airflow/example_dags/tutorial.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.8/_modules/airflow/exceptions.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors/base_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors/celery_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors/dask_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors/debug_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors/debug_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors/local_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.8/_modules/airflow/executors/sequential_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/S3_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/dbapi_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/docker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/druid_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/hdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/hive_hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/http_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/mssql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/mysql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/oracle_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/pig_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/postgres_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/presto_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/samba_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/slack_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/sqlite_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/webhdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.8/_modules/airflow/hooks/zendesk_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/macros.html
+++ b/docs-archive/1.10.8/_modules/airflow/macros.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.8/_modules/airflow/macros/hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models.html
+++ b/docs-archive/1.10.8/_modules/airflow/models.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/base.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/baseoperator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/chart.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/connection.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/crypto.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/dagbag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/dagpickle.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/dagrun.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/errors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/knownevent.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/kubernetes.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/log.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/pool.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/serialized_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/skipmixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/slamiss.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/taskfail.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/taskinstance.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/taskreschedule.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/user.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/variable.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.8/_modules/airflow/models/xcom.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/branch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/dagrun_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/docker_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/druid_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/dummy_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/email_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/generic_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/hive_stats_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/hive_to_druid.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/hive_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/hive_to_samba_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/http_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/latest_only_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/mssql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/mssql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/mysql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/oracle_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/pig_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/postgres_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/presto_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/presto_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/s3_file_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/s3_to_hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/slack_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/sqlite_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/operators/subdag_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/base_sensor_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/external_task_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/http_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/s3_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/sql_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/time_delta_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/time_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.8/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.8/_modules/airflow/utils/log/logging_mixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/_modules/index.html
+++ b/docs-archive/1.10.8/_modules/index.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/api.html
+++ b/docs-archive/1.10.8/api.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/best-practices.html
+++ b/docs-archive/1.10.8/best-practices.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/changelog.html
+++ b/docs-archive/1.10.8/changelog.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/cli.html
+++ b/docs-archive/1.10.8/cli.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/concepts.html
+++ b/docs-archive/1.10.8/concepts.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/configurations-ref.html
+++ b/docs-archive/1.10.8/configurations-ref.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/dag-serialization.html
+++ b/docs-archive/1.10.8/dag-serialization.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/errors.html
+++ b/docs-archive/1.10.8/errors.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/executor/celery.html
+++ b/docs-archive/1.10.8/executor/celery.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/executor/dask.html
+++ b/docs-archive/1.10.8/executor/dask.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/executor/debug.html
+++ b/docs-archive/1.10.8/executor/debug.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/executor/index.html
+++ b/docs-archive/1.10.8/executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/executor/kubernetes.html
+++ b/docs-archive/1.10.8/executor/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/executor/mesos.html
+++ b/docs-archive/1.10.8/executor/mesos.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/faq.html
+++ b/docs-archive/1.10.8/faq.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/genindex.html
+++ b/docs-archive/1.10.8/genindex.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/check-health.html
+++ b/docs-archive/1.10.8/howto/check-health.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/cli-completion.html
+++ b/docs-archive/1.10.8/howto/cli-completion.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/aws.html
+++ b/docs-archive/1.10.8/howto/connection/aws.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/gcp.html
+++ b/docs-archive/1.10.8/howto/connection/gcp.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.8/howto/connection/gcp_sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/grpc.html
+++ b/docs-archive/1.10.8/howto/connection/grpc.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/index.html
+++ b/docs-archive/1.10.8/howto/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/mysql.html
+++ b/docs-archive/1.10.8/howto/connection/mysql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/oracle.html
+++ b/docs-archive/1.10.8/howto/connection/oracle.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/postgres.html
+++ b/docs-archive/1.10.8/howto/connection/postgres.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/connection/ssh.html
+++ b/docs-archive/1.10.8/howto/connection/ssh.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/custom-operator.html
+++ b/docs-archive/1.10.8/howto/custom-operator.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/define_extra_link.html
+++ b/docs-archive/1.10.8/howto/define_extra_link.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/email-config.html
+++ b/docs-archive/1.10.8/howto/email-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/index.html
+++ b/docs-archive/1.10.8/howto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/initialize-database.html
+++ b/docs-archive/1.10.8/howto/initialize-database.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/bash.html
+++ b/docs-archive/1.10.8/howto/operator/bash.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/dingding.html
+++ b/docs-archive/1.10.8/howto/operator/dingding.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/external.html
+++ b/docs-archive/1.10.8/howto/operator/external.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/bigtable.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/cloud_build.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/compute.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/function.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/gcs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/gcs_to_gdrive.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/gcs_to_gdrive.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/natural_language.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/spanner.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/transfer.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/translate-speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/translate.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/video.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.8/howto/operator/gcp/vision.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/index.html
+++ b/docs-archive/1.10.8/howto/operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/papermill.html
+++ b/docs-archive/1.10.8/howto/operator/papermill.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/operator/python.html
+++ b/docs-archive/1.10.8/howto/operator/python.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.8/howto/run-behind-proxy.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/run-with-systemd.html
+++ b/docs-archive/1.10.8/howto/run-with-systemd.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/run-with-upstart.html
+++ b/docs-archive/1.10.8/howto/run-with-upstart.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/secure-connections.html
+++ b/docs-archive/1.10.8/howto/secure-connections.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/set-config.html
+++ b/docs-archive/1.10.8/howto/set-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.8/howto/tracking-user-activity.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/use-test-config.html
+++ b/docs-archive/1.10.8/howto/use-test-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/howto/write-logs.html
+++ b/docs-archive/1.10.8/howto/write-logs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/http-routingtable.html
+++ b/docs-archive/1.10.8/http-routingtable.html
@@ -40,7 +40,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/index.html
+++ b/docs-archive/1.10.8/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/installation.html
+++ b/docs-archive/1.10.8/installation.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/integration.html
+++ b/docs-archive/1.10.8/integration.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/kubernetes.html
+++ b/docs-archive/1.10.8/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/license.html
+++ b/docs-archive/1.10.8/license.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/lineage.html
+++ b/docs-archive/1.10.8/lineage.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/macros.html
+++ b/docs-archive/1.10.8/macros.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/metrics.html
+++ b/docs-archive/1.10.8/metrics.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/plugins.html
+++ b/docs-archive/1.10.8/plugins.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/privacy_notice.html
+++ b/docs-archive/1.10.8/privacy_notice.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/profiling.html
+++ b/docs-archive/1.10.8/profiling.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/project.html
+++ b/docs-archive/1.10.8/project.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/py-modindex.html
+++ b/docs-archive/1.10.8/py-modindex.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/scheduler.html
+++ b/docs-archive/1.10.8/scheduler.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/search.html
+++ b/docs-archive/1.10.8/search.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/security.html
+++ b/docs-archive/1.10.8/security.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/start.html
+++ b/docs-archive/1.10.8/start.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/timezone.html
+++ b/docs-archive/1.10.8/timezone.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/tutorial.html
+++ b/docs-archive/1.10.8/tutorial.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.8/ui.html
+++ b/docs-archive/1.10.8/ui.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/executors/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/executors/kubernetes_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/executors/kubernetes_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/executors/mesos_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/executors/mesos_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_athena_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_athena_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_dynamodb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_firehose_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_glue_catalog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_lambda_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_logs_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_logs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_sns_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_sns_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/aws_sqs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_container_instance_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_container_registry_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_container_volume_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_cosmos_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_data_lake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/azure_fileshare_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/bigquery_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/bigquery_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/cassandra_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/cassandra_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/cloudant_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/cloudant_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/databricks_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/databricks_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/datadog_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/datadog_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/datastore_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/datastore_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/dingding_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/dingding_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/discord_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/emr_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/emr_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/fs_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/fs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/ftp_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/ftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_api_base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_bigtable_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_cloud_build_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_compute_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_container_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_container_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_dataflow_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_dataproc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_dlp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_function_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_function_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_kms_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_mlengine_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_natural_language_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_pubsub_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_spanner_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_speech_to_text_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_text_to_speech_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_transfer_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_translate_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_video_intelligence_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcp_vision_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcs_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gcs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/gdrive_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/gdrive_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/grpc_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/grpc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/imap_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/imap_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/jenkins_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/jenkins_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/jira_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/jira_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/mongo_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/mongo_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/openfaas_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/openfaas_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/opsgenie_alert_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/pinot_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/pinot_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/qubole_check_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/qubole_check_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/qubole_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/qubole_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/redis_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/redis_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/redshift_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/redshift_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/sagemaker_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/sagemaker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/salesforce_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/salesforce_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/segment_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/segment_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/sftp_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/sftp_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/slack_webhook_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/snowflake_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/snowflake_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_jdbc_script/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_sql_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_sql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_submit_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/spark_submit_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/sqoop_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/sqoop_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/ssh_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/ssh_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/vertica_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/vertica_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/wasb_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/wasb_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/hooks/winrm_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/hooks/winrm_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/adls_list_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/adls_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/adls_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/adls_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/aws_athena_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/aws_athena_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/aws_sqs_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/awsbatch_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/awsbatch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/azure_container_instances_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/azure_cosmos_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_check_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_get_data/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_get_data/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_table_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_to_bigquery/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/bigquery_to_mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/cassandra_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/databricks_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/databricks_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/dataflow_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/dataflow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/dataproc_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/dataproc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/datastore_export_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/datastore_export_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/datastore_import_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/datastore_import_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/dingding_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/dingding_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/discord_webhook_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/discord_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/docker_swarm_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/docker_swarm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/druid_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/druid_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/dynamodb_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/ecs_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/ecs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/emr_add_steps_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/emr_create_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/emr_terminate_job_flow_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/file_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/file_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/file_to_wasb/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/file_to_wasb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_bigtable_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_cloud_build_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_compute_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_compute_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_container_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_container_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_dlp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_function_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_function_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_natural_language_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_spanner_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_speech_to_text_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_sql_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_text_to_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_transfer_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_translate_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_translate_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_translate_speech_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_video_intelligence_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_vision_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcp_vision_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_acl_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_acl_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_delete_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_delete_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_download_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_download_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_list_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_bq/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_bq/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_gdrive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_s3/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/gcs_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/hipchat_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/hipchat_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/hive_to_dynamodb/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/imap_attachment_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/jenkins_job_trigger_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/jira_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/jira_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/mlengine_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/mlengine_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/mongo_to_s3/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/mongo_to_s3/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/mssql_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/mssql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/mysql_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/mysql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/opsgenie_alert_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/oracle_to_azure_data_lake_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/oracle_to_oracle_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/postgres_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/pubsub_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/pubsub_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/qubole_check_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/qubole_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/qubole_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/qubole_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/redis_publish_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/redis_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_copy_object_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_delete_objects_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_list_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_list_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_to_gcs_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/s3_to_sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_base_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_endpoint_config_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_endpoint_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_model_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_training_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sagemaker_tuning_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/segment_track_event_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/segment_track_event_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sftp_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sftp_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sftp_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/slack_webhook_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/slack_webhook_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/snowflake_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/snowflake_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sns_publish_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sns_publish_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/spark_jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/spark_sql_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/spark_sql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/spark_submit_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/spark_submit_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sql_to_gcs/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sql_to_gcs/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/sqoop_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/sqoop_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/ssh_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/ssh_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/vertica_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/vertica_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/vertica_to_hive/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/vertica_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/vertica_to_mysql/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/vertica_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/wasb_delete_blob_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/operators/winrm_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/operators/winrm_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_athena_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_glue_catalog_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_redshift_cluster_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/aws_sqs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/azure_cosmos_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/bash_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/bash_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/bigquery_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/bigquery_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/cassandra_record_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/cassandra_table_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/datadog_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/datadog_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/emr_base_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/emr_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/emr_job_flow_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/emr_step_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/emr_step_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/file_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/file_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/ftp_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/ftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/gcp_transfer_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/gcs_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/gcs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/imap_attachment_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/jira_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/jira_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/mongo_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/mongo_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/pubsub_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/pubsub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/python_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/python_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/qubole_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/qubole_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/redis_key_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/redis_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/redis_pub_sub_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_base_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_endpoint_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_training_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_transform_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/sagemaker_tuning_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/sftp_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/sftp_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/wasb_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/wasb_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/contrib/sensors/weekday_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/contrib/sensors/weekday_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/base_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/celery_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/dask_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/debug_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/debug_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/local_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/executors/sequential_executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/S3_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/base_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/dbapi_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/docker_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/druid_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/hdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/hive_hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/http_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/jdbc_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/mssql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/mysql_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/oracle_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/pig_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/postgres_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/presto_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/samba_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/slack_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/sqlite_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/webhdfs_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/1.10.9/_api/airflow/hooks/zendesk_hook/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/base/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/base/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/baseoperator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/chart/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/chart/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/connection/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/crypto/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/crypto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/dag/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/dagbag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/dagpickle/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/dagrun/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/errors/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/errors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/knownevent/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/knownevent/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/kubernetes/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/kubernetes/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/log/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/log/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/pool/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/pool/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/serialized_dag/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/skipmixin/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/slamiss/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/taskfail/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/taskinstance/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/taskreschedule/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/user/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/user/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/variable/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/variable/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/models/xcom/index.html
+++ b/docs-archive/1.10.9/_api/airflow/models/xcom/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/bash_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/branch_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/dagrun_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/docker_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/druid_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/dummy_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/email_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/generic_transfer/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/hive_stats_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/hive_to_druid/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/hive_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/http_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/jdbc_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/latest_only_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/mssql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/mssql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/mysql_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/mysql_to_hive/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/oracle_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/papermill_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/pig_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/postgres_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/presto_check_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/presto_to_mysql/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/python_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/sensors/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/slack_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/sqlite_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/operators/subdag_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/base_sensor_operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/external_task_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/http_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/s3_key_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/sql_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/time_delta_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/time_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/1.10.9/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_api/index.html
+++ b/docs-archive/1.10.9/_api/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/configuration.html
+++ b/docs-archive/1.10.9/_modules/airflow/configuration.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_dingding_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_bigtable_operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_cloud_build.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_compute.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_compute.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_compute_igm.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_function.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_function.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_natural_language.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_spanner.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_speech.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_speech.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_sql.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_sql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_sql_query.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_translate.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_translate.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_video_intelligence.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_vision.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcp_vision.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcs_acl.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcs_acl.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcs_to_bq_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_gcs_to_gdrive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_papermill_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/example_dags/example_papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/executors/kubernetes_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/executors/kubernetes_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/executors/mesos_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/executors/mesos_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_athena_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_athena_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_dynamodb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_firehose_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_firehose_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_glue_catalog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_lambda_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_lambda_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_logs_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_logs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_sns_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_sns_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_sqs_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/aws_sqs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_container_instance_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_container_registry_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_container_volume_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_cosmos_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_data_lake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/azure_fileshare_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/bigquery_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/bigquery_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/cassandra_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/cassandra_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/cloudant_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/cloudant_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/databricks_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/databricks_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/datadog_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/datadog_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/datastore_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/datastore_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/dingding_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/dingding_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/discord_webhook_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/discord_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/emr_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/emr_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/fs_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/fs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/ftp_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/ftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_api_base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_bigtable_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_cloud_build_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_compute_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_compute_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_container_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_container_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_dataflow_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_dataproc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_dlp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_function_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_function_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_kms_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_kms_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_mlengine_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_natural_language_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_pubsub_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_spanner_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_speech_to_text_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_sql_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_text_to_speech_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_transfer_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_translate_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_translate_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_video_intelligence_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_vision_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcp_vision_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcs_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gcs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gdrive_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/gdrive_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/grpc_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/grpc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/imap_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/imap_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/jenkins_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/jenkins_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/jira_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/jira_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/mongo_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/mongo_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/openfaas_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/openfaas_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/opsgenie_alert_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/pinot_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/pinot_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/qubole_check_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/qubole_check_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/qubole_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/qubole_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/redis_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/redis_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/redshift_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/redshift_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/sagemaker_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/sagemaker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/salesforce_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/salesforce_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/segment_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/segment_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/sftp_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/sftp_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/slack_webhook_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/slack_webhook_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/snowflake_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/snowflake_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_jdbc_script.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_jdbc_script.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_sql_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_sql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_submit_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/spark_submit_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/sqoop_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/sqoop_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/ssh_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/ssh_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/vertica_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/vertica_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/wasb_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/wasb_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/hooks/winrm_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/hooks/winrm_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/adls_list_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/adls_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/adls_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/adls_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/aws_athena_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/aws_athena_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/aws_sqs_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/awsbatch_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/awsbatch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/azure_container_instances_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/azure_container_instances_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/azure_cosmos_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/azure_cosmos_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_check_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_get_data.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_get_data.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_table_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_to_bigquery.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/bigquery_to_mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/cassandra_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/cassandra_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/databricks_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/databricks_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/dataflow_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/dataflow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/dataproc_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/dataproc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/datastore_export_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/datastore_export_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/datastore_import_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/datastore_import_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/dingding_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/dingding_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/discord_webhook_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/discord_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/docker_swarm_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/docker_swarm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/druid_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/druid_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/dynamodb_to_s3.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/dynamodb_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/ecs_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/ecs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/emr_add_steps_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/emr_add_steps_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/emr_create_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/emr_terminate_job_flow_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/file_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/file_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/file_to_wasb.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/file_to_wasb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_bigtable_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_cloud_build_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_compute_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_compute_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_container_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_container_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_dlp_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_dlp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_function_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_function_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_natural_language_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_spanner_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_spanner_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_speech_to_text_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_sql_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_text_to_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_transfer_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_transfer_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_translate_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_translate_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_translate_speech_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_video_intelligence_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_vision_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcp_vision_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_acl_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_acl_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_delete_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_delete_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_download_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_download_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_list_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_bq.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_bq.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_gdrive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_s3.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/gcs_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/hipchat_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/hipchat_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/hive_to_dynamodb.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/hive_to_dynamodb.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/imap_attachment_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/jenkins_job_trigger_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/jira_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/jira_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/kubernetes_pod_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/mlengine_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/mlengine_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/mongo_to_s3.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/mongo_to_s3.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/mssql_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/mssql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/mysql_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/mysql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/opsgenie_alert_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/oracle_to_oracle_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/postgres_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/pubsub_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/pubsub_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/qubole_check_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/qubole_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/qubole_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/qubole_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/redis_publish_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/redis_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_copy_object_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_copy_object_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_delete_objects_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_list_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_list_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_to_gcs_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/s3_to_sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_base_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_base_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_endpoint_config_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_endpoint_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_model_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_model_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_training_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_training_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sagemaker_tuning_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/segment_track_event_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/segment_track_event_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sftp_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sftp_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sftp_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/slack_webhook_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/slack_webhook_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/snowflake_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/snowflake_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sns_publish_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sns_publish_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/spark_jdbc_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/spark_jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/spark_sql_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/spark_sql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/spark_submit_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/spark_submit_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sql_to_gcs.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sql_to_gcs.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/sqoop_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/sqoop_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/ssh_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/ssh_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/vertica_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/vertica_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/vertica_to_hive.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/vertica_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/vertica_to_mysql.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/vertica_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/wasb_delete_blob_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/operators/winrm_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/operators/winrm_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_athena_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_athena_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_glue_catalog_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_redshift_cluster_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/aws_sqs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/azure_cosmos_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/bash_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/bash_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/bigquery_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/bigquery_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/cassandra_record_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/cassandra_table_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/datadog_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/datadog_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/emr_base_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/emr_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/emr_job_flow_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/emr_step_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/emr_step_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/file_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/file_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/ftp_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/ftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/gcp_transfer_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/gcs_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/gcs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/imap_attachment_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/jira_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/jira_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/mongo_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/mongo_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/pubsub_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/pubsub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/python_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/python_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/qubole_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/qubole_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/redis_key_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/redis_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/redis_pub_sub_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_base_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_endpoint_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_training_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_transform_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sagemaker_tuning_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sftp_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/sftp_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/wasb_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/wasb_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/contrib/sensors/weekday_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/contrib/sensors/weekday_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/example_dags/example_bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/example_dags/example_external_task_marker_dag.html
+++ b/docs-archive/1.10.9/_modules/airflow/example_dags/example_external_task_marker_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/example_dags/example_python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/example_dags/tutorial.html
+++ b/docs-archive/1.10.9/_modules/airflow/example_dags/tutorial.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/exceptions.html
+++ b/docs-archive/1.10.9/_modules/airflow/exceptions.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors/base_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors/celery_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors/dask_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors/debug_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors/debug_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors/local_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/1.10.9/_modules/airflow/executors/sequential_executor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/S3_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/S3_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/base_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/base_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/dbapi_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/dbapi_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/docker_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/docker_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/druid_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/druid_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/hdfs_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/hdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/hive_hooks.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/hive_hooks.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/http_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/http_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/jdbc_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/jdbc_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/mssql_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/mssql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/mysql_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/mysql_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/oracle_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/oracle_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/pig_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/pig_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/postgres_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/postgres_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/presto_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/presto_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/samba_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/samba_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/slack_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/slack_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/sqlite_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/sqlite_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/webhdfs_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/webhdfs_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/hooks/zendesk_hook.html
+++ b/docs-archive/1.10.9/_modules/airflow/hooks/zendesk_hook.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/macros.html
+++ b/docs-archive/1.10.9/_modules/airflow/macros.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/macros/hive.html
+++ b/docs-archive/1.10.9/_modules/airflow/macros/hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models.html
+++ b/docs-archive/1.10.9/_modules/airflow/models.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/base.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/base.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/baseoperator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/chart.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/chart.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/connection.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/connection.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/crypto.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/crypto.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/dag.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/dagbag.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/dagbag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/dagpickle.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/dagrun.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/dagrun.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/errors.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/errors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/knownevent.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/knownevent.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/kubernetes.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/kubernetes.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/log.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/log.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/pool.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/pool.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/serialized_dag.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/skipmixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/slamiss.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/slamiss.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/taskfail.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/taskfail.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/taskinstance.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/taskreschedule.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/user.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/user.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/variable.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/variable.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/models/xcom.html
+++ b/docs-archive/1.10.9/_modules/airflow/models/xcom.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/bash_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/bash_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/branch_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/branch_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/dagrun_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/dagrun_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/docker_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/docker_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/druid_check_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/druid_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/dummy_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/dummy_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/email_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/email_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/generic_transfer.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/hive_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/hive_stats_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/hive_stats_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/hive_to_druid.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/hive_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/hive_to_samba_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/hive_to_samba_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/http_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/http_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/jdbc_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/jdbc_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/latest_only_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/latest_only_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/mssql_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/mssql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/mssql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/mysql_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/mysql_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/mysql_to_hive.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/oracle_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/oracle_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/papermill_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/papermill_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/pig_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/pig_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/postgres_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/postgres_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/presto_check_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/presto_to_mysql.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/python_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/python_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/s3_file_transform_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/s3_file_transform_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/s3_to_hive_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/sensors.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/slack_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/slack_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/sqlite_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/sqlite_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/operators/subdag_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/operators/subdag_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/base_sensor_operator.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/base_sensor_operator.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/external_task_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/external_task_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/hdfs_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/hive_partition_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/http_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/http_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/metastore_partition_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/metastore_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/named_hive_partition_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/named_hive_partition_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/s3_key_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/s3_key_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/s3_prefix_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/s3_prefix_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/sql_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/sql_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/time_delta_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/time_delta_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/time_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/sensors/web_hdfs_sensor.html
+++ b/docs-archive/1.10.9/_modules/airflow/sensors/web_hdfs_sensor.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/airflow/utils/log/logging_mixin.html
+++ b/docs-archive/1.10.9/_modules/airflow/utils/log/logging_mixin.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/_modules/index.html
+++ b/docs-archive/1.10.9/_modules/index.html
@@ -33,7 +33,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/api.html
+++ b/docs-archive/1.10.9/api.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/best-practices.html
+++ b/docs-archive/1.10.9/best-practices.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/changelog.html
+++ b/docs-archive/1.10.9/changelog.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/cli.html
+++ b/docs-archive/1.10.9/cli.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/concepts.html
+++ b/docs-archive/1.10.9/concepts.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/configurations-ref.html
+++ b/docs-archive/1.10.9/configurations-ref.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/dag-serialization.html
+++ b/docs-archive/1.10.9/dag-serialization.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/errors.html
+++ b/docs-archive/1.10.9/errors.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/executor/celery.html
+++ b/docs-archive/1.10.9/executor/celery.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/executor/dask.html
+++ b/docs-archive/1.10.9/executor/dask.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/executor/debug.html
+++ b/docs-archive/1.10.9/executor/debug.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/executor/index.html
+++ b/docs-archive/1.10.9/executor/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/executor/kubernetes.html
+++ b/docs-archive/1.10.9/executor/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/executor/mesos.html
+++ b/docs-archive/1.10.9/executor/mesos.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/faq.html
+++ b/docs-archive/1.10.9/faq.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/genindex.html
+++ b/docs-archive/1.10.9/genindex.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/check-health.html
+++ b/docs-archive/1.10.9/howto/check-health.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/cli-completion.html
+++ b/docs-archive/1.10.9/howto/cli-completion.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/aws.html
+++ b/docs-archive/1.10.9/howto/connection/aws.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/gcp.html
+++ b/docs-archive/1.10.9/howto/connection/gcp.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/gcp_sql.html
+++ b/docs-archive/1.10.9/howto/connection/gcp_sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/grpc.html
+++ b/docs-archive/1.10.9/howto/connection/grpc.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/index.html
+++ b/docs-archive/1.10.9/howto/connection/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/mysql.html
+++ b/docs-archive/1.10.9/howto/connection/mysql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/oracle.html
+++ b/docs-archive/1.10.9/howto/connection/oracle.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/postgres.html
+++ b/docs-archive/1.10.9/howto/connection/postgres.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/connection/ssh.html
+++ b/docs-archive/1.10.9/howto/connection/ssh.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/custom-operator.html
+++ b/docs-archive/1.10.9/howto/custom-operator.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/define_extra_link.html
+++ b/docs-archive/1.10.9/howto/define_extra_link.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/email-config.html
+++ b/docs-archive/1.10.9/howto/email-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/index.html
+++ b/docs-archive/1.10.9/howto/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/initialize-database.html
+++ b/docs-archive/1.10.9/howto/initialize-database.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/bash.html
+++ b/docs-archive/1.10.9/howto/operator/bash.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/dingding.html
+++ b/docs-archive/1.10.9/howto/operator/dingding.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/external.html
+++ b/docs-archive/1.10.9/howto/operator/external.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/bigtable.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/bigtable.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/cloud_build.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/cloud_build.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/compute.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/compute.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/function.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/function.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/gcs.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/gcs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/gcs_to_gdrive.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/gcs_to_gdrive.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/index.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/natural_language.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/natural_language.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/spanner.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/spanner.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/speech.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/sql.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/sql.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/transfer.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/transfer.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/translate-speech.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/translate-speech.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/translate.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/translate.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/video.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/video.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/gcp/vision.html
+++ b/docs-archive/1.10.9/howto/operator/gcp/vision.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/index.html
+++ b/docs-archive/1.10.9/howto/operator/index.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/papermill.html
+++ b/docs-archive/1.10.9/howto/operator/papermill.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/operator/python.html
+++ b/docs-archive/1.10.9/howto/operator/python.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/run-behind-proxy.html
+++ b/docs-archive/1.10.9/howto/run-behind-proxy.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/run-with-systemd.html
+++ b/docs-archive/1.10.9/howto/run-with-systemd.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/run-with-upstart.html
+++ b/docs-archive/1.10.9/howto/run-with-upstart.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/secure-connections.html
+++ b/docs-archive/1.10.9/howto/secure-connections.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/set-config.html
+++ b/docs-archive/1.10.9/howto/set-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/tracking-user-activity.html
+++ b/docs-archive/1.10.9/howto/tracking-user-activity.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/use-test-config.html
+++ b/docs-archive/1.10.9/howto/use-test-config.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/howto/write-logs.html
+++ b/docs-archive/1.10.9/howto/write-logs.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/http-routingtable.html
+++ b/docs-archive/1.10.9/http-routingtable.html
@@ -40,7 +40,14 @@ https://www.sphinx-doc.org/en/master/templating.html
     </script>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/index.html
+++ b/docs-archive/1.10.9/index.html
@@ -34,7 +34,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/installation.html
+++ b/docs-archive/1.10.9/installation.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/integration.html
+++ b/docs-archive/1.10.9/integration.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/kubernetes.html
+++ b/docs-archive/1.10.9/kubernetes.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/license.html
+++ b/docs-archive/1.10.9/license.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/lineage.html
+++ b/docs-archive/1.10.9/lineage.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/macros.html
+++ b/docs-archive/1.10.9/macros.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/metrics.html
+++ b/docs-archive/1.10.9/metrics.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/plugins.html
+++ b/docs-archive/1.10.9/plugins.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/privacy_notice.html
+++ b/docs-archive/1.10.9/privacy_notice.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/profiling.html
+++ b/docs-archive/1.10.9/profiling.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/project.html
+++ b/docs-archive/1.10.9/project.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/py-modindex.html
+++ b/docs-archive/1.10.9/py-modindex.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/scheduler.html
+++ b/docs-archive/1.10.9/scheduler.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/search.html
+++ b/docs-archive/1.10.9/search.html
@@ -36,7 +36,14 @@ https://www.sphinx-doc.org/en/master/templating.html
   </style>
 
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/security.html
+++ b/docs-archive/1.10.9/security.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/start.html
+++ b/docs-archive/1.10.9/start.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/timezone.html
+++ b/docs-archive/1.10.9/timezone.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/tutorial.html
+++ b/docs-archive/1.10.9/tutorial.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/docs-archive/1.10.9/ui.html
+++ b/docs-archive/1.10.9/ui.html
@@ -35,7 +35,14 @@ https://www.sphinx-doc.org/en/master/templating.html
 
   </style>
 
-</head><body class="td-section">
+<script type="application/javascript">
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga("create", "UA-140539454-1", "auto");
+ga("send", "pageview");
+</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+</head>
+<body class="td-section">
     
 
 <header>

--- a/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
@@ -297,7 +297,16 @@
             <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
         {%- endif %}
     {%- endblock %}
-    {%- block extrahead %} {% endblock %}
+    <script type="application/javascript">
+        var doNotTrack = false;
+        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+        ga('create', 'UA-140539454-1', 'auto');
+        ga('send', 'pageview');
+    </script>
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+    {%- block extrahead %}
+
+    {% endblock %}
 </head>
 
 {%- block body_tag %}<body class="td-section">{% endblock %}


### PR DESCRIPTION
Close: https://github.com/apache/airflow-site/issues/298


I used the Bash script below (Mac OS only) to make changes to docs-archive.
```bash
grep -R -L 'UA-140539454-1' docs-archive/ | grep ".html$" | pv -betlap | xargs sed -i '' 's#<\/head>#<script\ type\=\"application\/javascript\"\>\
window\.ga\=window\.ga\|\|function\(\)\{\(ga\.q\=ga\.q\|\|\[\]\)\.push\(arguments\)\}\;ga\.l\=\+new\ Date\;\
ga\(\"create\"\,\ \"UA\-140539454\-1\"\,\ \"auto\"\)\;\
ga\(\"send\"\,\ \"pageview\"\)\;\
\<\/script\>\
\<script\ async\ src\=\"https\:\/\/www\.google\-analytics\.com\/analytics\.js\"\>\<\/script\>\
<\/head>\
#'

```