### PR TITLE
Customizable navbar

### DIFF
--- a/sphinx_airflow_theme/demo/docs.sh
+++ b/sphinx_airflow_theme/demo/docs.sh
@@ -41,7 +41,12 @@ EOF
 function ensure_that_documentation_is_built {
     if [[ ! -f _build/html/index.html ]] ; then
         echo "Documentation is not built. Start build."
-        sphinx-build -M html "${SOURCE_DIR}" "${BUILD_DIR}" -E
+        # -E  don't use a saved environment, always read all files
+        # -T  show full traceback on exception
+        sphinx-build \
+            -E \
+            -T \
+            "${SOURCE_DIR}" "${BUILD_DIR}"
     fi
 }
 

--- a/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from os import path
+from sphinx.application import Sphinx
 
 __version__ = '0.0.1'
 __version_full__ = __version__
@@ -27,7 +28,27 @@ def get_html_theme_path():
     return cur_dir
 
 
+def setup_my_func(app, pagename, templatename, context, doctree):
+    context["navbar_links"] = app.config.sphinx_airflow_theme_navbar_links
+    context["hide_install_button"] = app.config.sphinx_airflow_theme_hide_install_button
+
+
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
-def setup(app):
+def setup(app: Sphinx):
+    app.add_config_value(
+        'sphinx_airflow_theme_navbar_links',
+        default=[
+            {'href': '/docs/', 'text': 'Documentation'}
+        ],
+        rebuild='html'
+    )
+    app.add_config_value(
+        'sphinx_airflow_theme_hide_install_button',
+        default=False,
+        rebuild='html',
+        types=[bool]
+    )
+
     app.add_html_theme('sphinx_airflow_theme', path.abspath(path.dirname(__file__)))
     app.add_stylesheet('_gen/css//main-custom.min.css')
+    app.connect("html-page-context", setup_my_func)

--- a/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
@@ -30,7 +30,9 @@ def get_html_theme_path():
 
 def setup_my_func(app, pagename, templatename, context, doctree):
     context["navbar_links"] = app.config.sphinx_airflow_theme_navbar_links
-    context["hide_install_button"] = app.config.sphinx_airflow_theme_hide_install_button
+    context["hide_website_buttons"] = (
+        app.config.sphinx_airflow_theme_hide_website_buttons
+    )
 
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
@@ -43,7 +45,7 @@ def setup(app: Sphinx):
         rebuild='html'
     )
     app.add_config_value(
-        'sphinx_airflow_theme_hide_install_button',
+        'sphinx_airflow_theme_hide_website_buttons',
         default=False,
         rebuild='html',
         types=[bool]

--- a/sphinx_airflow_theme/sphinx_airflow_theme/footer.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/footer.html
@@ -90,6 +90,8 @@
             </a>
 
         </div>
+        {% if hide_website_buttons %}
+
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
             <a href="/community">
@@ -98,6 +100,8 @@
 
             </a>
         </div>
+        {% endif %}
+
     </div>
     <div class="footer-section footer-section__policies-section">
         <div class="footer-section">
@@ -119,6 +123,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
+                {% if hide_website_buttons %}
 
                 <a href="/docs" class="footer-section__policies-section--policy-item">
                     <span>Season of Docs</span>
@@ -144,6 +149,8 @@
                     </div>
 
                 </div>
+                {% endif %}
+
             </div>
         </div>
         <span class="footer-section__policies-section--disclaimer">

--- a/sphinx_airflow_theme/sphinx_airflow_theme/header.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/header.html
@@ -123,7 +123,7 @@
                         <button id="" class="btn-filled bodytext__medium--white ">Install</button>
 
                     </a>
-                    {% if hide_website_buttons %}
+                    {% endif %}
 
                 </div>
             </div>

--- a/sphinx_airflow_theme/sphinx_airflow_theme/header.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/header.html
@@ -55,51 +55,19 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-
-                    <a class="navbar__text-link " href="/community/">
-                        Community
-                    </a>
-
-                    <a class="navbar__text-link " href="/meetups/">
-                        Meetups
-                    </a>
-
-                    <a class="navbar__text-link " href="/docs/">
-                        Documentation
-                    </a>
-
-                    {#
-                    TODO: Temporary solution. Uncomment when roadmap content is ready.
-
-                    <a class="navbar__text-link " href="/roadmap/">
-                        Roadmap
-                    </a>
-                    #}
-
-                    <a class="navbar__text-link " href="/use-cases/">
-                        Use cases
-                    </a>
-
-                    <a class="navbar__text-link " href="/blog/">
-                        Blog
-                    </a>
+                    {% for link in navbar_links %}
+                        <a class="navbar__text-link" href="{{ link.href }}/">
+                            {{ link.text }}
+                        </a>
+                    {% endfor %}
 
                 </div>
 
-                {#
-                TODO: Temporary solution. Replace the link to docs with commented code when texts on install page are ready.
-
-                <a href="/install/">
-
-                    <button id="" class="btn-filled bodytext__medium--white ">Install</button>
-
-                </a>
-                #}
+                {% if hide_install_button %}
                 <a href="/docs/stable/start.html">
-
-                    <button id="" class="btn-filled bodytext__medium--white ">Install</button>
-
+                    <button class="btn-filled bodytext__medium--white">Install</button>
                 </a>
+                {% endif %}
 
             </div>
 

--- a/sphinx_airflow_theme/sphinx_airflow_theme/header.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/header.html
@@ -60,10 +60,9 @@
                             {{ link.text }}
                         </a>
                     {% endfor %}
-
                 </div>
 
-                {% if hide_install_button %}
+                {% if hide_website_buttons %}
                 <a href="/docs/stable/start.html">
                     <button class="btn-filled bodytext__medium--white">Install</button>
                 </a>
@@ -111,38 +110,20 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-
-                        <a class="navbar__text-link " href="/community/">
-                            Community
-                        </a>
-
-                        <a class="navbar__text-link " href="/meetups/">
-                            Meetups
-                        </a>
-
-                        <a class="navbar__text-link " href="/docs/">
-                            Documentation
-                        </a>
-
-                        <a class="navbar__text-link " href="/roadmap/">
-                            Roadmap
-                        </a>
-
-                        <a class="navbar__text-link " href="/use-cases/">
-                            Use cases
-                        </a>
-
-                        <a class="navbar__text-link " href="/blog/">
-                            Blog
-                        </a>
+                        {% for link in navbar_links %}
+                            <a class="navbar__text-link" href="{{ link.href }}/">
+                                {{ link.text }}
+                            </a>
+                        {% endfor %}
 
                     </div>
-
+                    {% if hide_website_buttons %}
                     <a href="/install/">
 
                         <button id="" class="btn-filled bodytext__medium--white ">Install</button>
 
                     </a>
+                    {% if hide_website_buttons %}
 
                 </div>
             </div>


### PR DESCRIPTION
Hello,

To be able to use this theme for development documentation as well, I need to make a few more changes to the navbar.

In development documentation, we will only have one button to index the documentation. The rest of the buttons are irrelevant in the documentation and are part of the website.

Part of: https://github.com/apache/airflow/issues/11423