### PR TITLE
Fix url of last breadcrumb-item (#302)

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/breadcrumbs.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/breadcrumbs.html
@@ -35,7 +35,7 @@
             {% for doc in parents %}
                 <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
             {% endfor %}
-            <li class="breadcrumb-item"><a href="{{ pagename }}{{ file_suffix }}"> {{ title }}</a></li>
+            <li class="breadcrumb-item"><a href="{{ pagename.split('/')[-1] }}{{ file_suffix }}"> {{ title }}</a></li>
         {% endblock %}
     </ul>
 </div>


### PR DESCRIPTION
This fixes the underlying issue with #302 which was that the last breadcrumb-item had an incorrect url that included the parent directory twice. Prior to 0adef64b932d7088bc6b2d84d8bf19a1375cb885, the h1 element was linked to this url as well as the last breadcrumb-item, resulting in the behavior originally described.