### PR TITLE
Copy docs for stable version to /docs/stable/

### DIFF
--- a/site.sh
+++ b/site.sh
@@ -262,7 +262,7 @@ function build_site {
         version="$(basename -- "${doc_path}")"
         verbose_copy "${doc_path}" "dist/docs/${version}/"
     done
-    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)" "dist/docs/stable/"
+    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)/" "dist/docs/stable/"
     create_index dist/docs
 }
 


### PR DESCRIPTION
Hello,

The documentation is copied. to the wrong directory
Before:
https://airflow.apache.org/docs/stable/1.10.13/macros-ref.html
After:
https://airflow.apache.org/docs/stable/macros-ref.html

Best regards,
Kamil