### PR TITLE
User-friendly output for site.sh (#319) Copy docs for stable version to /docs/stable/ (#321) + Sanity checks

### DIFF
--- a/site.sh
+++ b/site.sh
@@ -262,7 +262,7 @@ function build_site {
         version="$(basename -- "${doc_path}")"
         verbose_copy "${doc_path}" "dist/docs/${version}/"
     done
-    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)" "dist/docs/stable/"
+    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)/" "dist/docs/stable/"
     create_index dist/docs
 }
 

--- a/site.sh
+++ b/site.sh
@@ -26,9 +26,7 @@ IMAGE_NAME=airflow-site
 CONTAINER_NAME=airflow-site-c
 
 function log {
-    GRAY='\033[1;30m'
-    NC='\033[0m' # No Color
-    echo -e "${GRAY}$(date +'%Y-%m-%d %H:%M:%S'):INFO: ${*} ${NC}" >&2;
+    echo -e "$(date +'%Y-%m-%d %H:%M:%S'):INFO: ${*} " >&2;
 }
 
 function usage {
@@ -247,6 +245,14 @@ function verbose_copy {
     cp -R "$source" "$target"
 }
 
+function assert_file_exists {
+    file_path="$1"
+    if [[ ! -f "${file_path}" ]]; then
+        echo "Missing file: ${file_path}":
+        exit 1
+    fi
+}
+
 function build_site {
     log "Building full site"
 
@@ -260,10 +266,15 @@ function build_site {
     rm -rf dist/docs/*
     for doc_path in docs-archive/*/ ; do
         version="$(basename -- "${doc_path}")"
-        verbose_copy "${doc_path}" "dist/docs/${version}/"
+        verbose_copy "docs-archive/${version}/." "dist/docs/${version}"
     done
-    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)/" "dist/docs/stable/"
+    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)/." "dist/docs/stable"
     create_index dist/docs
+
+    # Sanity checks
+    assert_file_exists dist/docs/1.10.7/tutorial.html
+    assert_file_exists dist/docs/stable/tutorial.html
+    assert_file_exists dist/docs/index.html
 }
 
 

--- a/site.sh
+++ b/site.sh
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-set -euox pipefail
+set -euo pipefail
 
 WORKING_DIR="$(pwd)"
 MY_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -24,6 +24,12 @@ pushd "${MY_DIR}" &>/dev/null || exit 1
 
 IMAGE_NAME=airflow-site
 CONTAINER_NAME=airflow-site-c
+
+function log {
+    GRAY='\033[1;30m'
+    NC='\033[0m' # No Color
+    echo -e "${GRAY}$(date +'%Y-%m-%d %H:%M:%S'):INFO: ${*} ${NC}" >&2;
+}
 
 function usage {
 cat << EOF
@@ -62,15 +68,17 @@ EOF
 }
 
 function ensure_image_exists {
+    log "Checking if image exists: ${IMAGE_NAME}"
     if [[ ! $(docker images "${IMAGE_NAME}" -q) ]]; then
-        echo "Image not exists."
+        log "Image not exists."
         build_image
     fi
 }
 
 function ensure_container_exists {
+    log "Checking if container exists: ${CONTAINER_NAME}"
     if [[ ! $(docker container ls -a --filter="Name=${CONTAINER_NAME}" -q ) ]]; then
-        echo "Container not exists"
+        log "Container not exists"
         docker run \
             --detach \
             --name "${CONTAINER_NAME}" \
@@ -83,37 +91,41 @@ function ensure_container_exists {
 }
 
 function ensure_container_running {
+    log "Checking if container running: ${CONTAINER_NAME}"
     container_status="$(docker inspect "${CONTAINER_NAME}" --format '{{.State.Status}}')"
-    echo "Current container status: ${container_status}"
+    log "Current container status: ${container_status}"
     if [[ ! "${container_status}" == "running" ]]; then
-        echo "Container not running. Starting the container."
+        log "Container not running. Starting the container."
         docker start "${CONTAINER_NAME}"
     fi
 }
 
 function ensure_node_module_exists {
+    log "Checking if node module exists"
     if [[ ! -d landing-pages/node_modules/ ]] ; then
-        echo "Missing node dependencies. Start installation."
+        log "Missing node dependencies. Start installation."
         run_command "/opt/site/landing-pages/" yarn install
-        echo "Dependencies installed."
+        log "Dependencies installed."
     fi
 }
 
 function ensure_that_website_is_build {
+    log "Check if landing-pages/dist/index.html file exists"
     if [[ ! -f landing-pages/dist/index.html ]] ; then
-        echo "The website is not built. Start building."
+        log "The website is not built. Start building."
         run_command "/opt/site/landing-pages/" npm run build
-        echo "The website builded."
+        log "The website builded."
     fi
 }
 
 function build_image {
-    echo "Start building image"
+    log "Start building image"
     docker build -t airflow-site .
-    echo "End building image"
+    log "End building image"
 }
 
 function run_command {
+    log "Running command: $*"
     working_directory=$1
     shift
     if [[ -f /.dockerenv ]] ; then
@@ -136,6 +148,7 @@ function run_command {
 }
 
 function prepare_environment {
+    log "Preparing environment"
     if [[ ! -f /.dockerenv ]] ; then
         ensure_image_exists
         ensure_container_exists
@@ -202,30 +215,22 @@ function run_lint {
 }
 
 function prepare_docs_index {
+    log "Preparing docs index"
     run_command "/opt/site/docs-archive/" ./show_docs_index_json.sh > landing-pages/site/static/_gen/docs-index.json
 }
 
 function build_landing_pages {
+    log "Building landing pages"
     run_command "/opt/site/landing-pages/" npm run index
     prepare_docs_index
     run_command "/opt/site/landing-pages/" npm run build
 }
 
-function build_site {
-    if [[ ! -f "landing-pages/dist/index.html" ]]; then
-        build_landing_pages
-    fi
-    mkdir -p dist
-    rm -rf dist/*
-    cp -R landing-pages/dist/. dist/
-    mkdir -p dist/docs/
-    rm -rf dist/docs/*
-    for doc_path in docs-archive/*/ ; do
-        version="$(basename -- "${doc_path}")"
-        cp -R "${doc_path}" "dist/docs/${version}/"
-    done
-    cp -R "docs-archive/$(cat docs-archive/stable.txt)" "dist/docs/stable/"
-    cat > dist/docs/index.html << EOF
+function create_index {
+    output_path="$1/index.html"
+    log "Creating index: ${output_path}"
+
+    cat > "${output_path}" << EOF
 <!DOCTYPE html>
 <html>
    <head><meta http-equiv="refresh" content="1; url=stable/" /></head>
@@ -234,27 +239,55 @@ function build_site {
 EOF
 }
 
+function verbose_copy {
+    source="$1"
+    target="$2"
+    log "Copying '$source' to '$target'"
+    mkdir -p "${target}"
+    cp -R "$source" "$target"
+}
+
+function build_site {
+    log "Building full site"
+
+    if [[ ! -f "landing-pages/dist/index.html" ]]; then
+        build_landing_pages
+    fi
+    mkdir -p dist
+    rm -rf dist/*
+    verbose_copy landing-pages/dist/. dist/
+    mkdir -p dist/docs/
+    rm -rf dist/docs/*
+    for doc_path in docs-archive/*/ ; do
+        version="$(basename -- "${doc_path}")"
+        verbose_copy "${doc_path}" "dist/docs/${version}/"
+    done
+    verbose_copy "docs-archive/$(cat docs-archive/stable.txt)" "dist/docs/stable/"
+    create_index dist/docs
+}
+
 
 function cleanup_environment {
     container_status="$(docker inspect "${CONTAINER_NAME}" --format '{{.State.Status}}')"
-    echo "Current container status: ${container_status}"
+    log "Current container status: ${container_status}"
     if [[ "${container_status}" == "running" ]]; then
-        echo "Container running. Killing the container."
+        log "Container running. Killing the container."
         docker kill "${CONTAINER_NAME}"
     fi
 
     if [[ $(docker container ls -a --filter="Name=${CONTAINER_NAME}" -q ) ]]; then
-        echo "Container exists. Removing the container."
+        log "Container exists. Removing the container."
         docker rm "${CONTAINER_NAME}"
     fi
 
     if [[ $(docker images "${IMAGE_NAME}" -q) ]]; then
-        echo "Images exists. Deleeting the image."
+        log "Images exists. Deleting the image."
         docker rmi "${IMAGE_NAME}"
     fi
 }
 
 function prepare_theme {
+    log "Preparing theme files"
     SITE_DIST="landing-pages/dist"
     THEME_GEN="sphinx_airflow_theme/sphinx_airflow_theme/static/_gen"
     mkdir -p "${THEME_GEN}/css" "${THEME_GEN}/js"


### PR DESCRIPTION
Hello,

This PR brings back all changes reverted by https://github.com/apache/airflow-site/pull/322
*  fix two bugs: 
 - Github Action displays consoles correctly.
  - Documentation is copied to the correct directories on MacOS and Linux.
*  add sanity checks

Best regards,
Kamil Breguła