### PR TITLE
Add theme options to theme.conf

### DIFF
--- a/sphinx_airflow_theme/README.md
+++ b/sphinx_airflow_theme/README.md
@@ -57,25 +57,31 @@ the CI builds your PR.
 
 # Configuration
 
-A theme that supports the following configuration options:
+A theme that supports the following configuration options under the `html_theme_options` dict in your projects `conf.py`:
 
-## `sphinx_airflow_theme_navbar_links`
+## `navbar_links`
 
 The list of links that should be available in the navigation bar at the top of the pages. The order of items will not be changed.
 
 **Example values:**
-```
-[
-    {'href': '/docs/', 'text': 'Documentation'}
-]
+```python
+html_theme_options = {
+    'navbar_links': [
+        {'href': '/docs/', 'text': 'Documentation'}
+    ]
 ```
 
-## `sphinx_airflow_theme_hide_website_buttons`
+(This is the default)
+
+## `hide_website_buttons`
+
 If ``True``, all links on the same domain but not pointing to this theme's page (e.g. `/community/`) will be hidden.
 
 **Example values:**
-```
-False
+```python
+html_theme_options = {
+  'hide_website_buttons': False,
+}
 ```
 
 # Theme's source files

--- a/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
@@ -28,29 +28,13 @@ def get_html_theme_path():
     return cur_dir
 
 
-def setup_my_func(app, pagename, templatename, context, doctree):
-    context["navbar_links"] = app.config.sphinx_airflow_theme_navbar_links
-    context["hide_website_buttons"] = (
-        app.config.sphinx_airflow_theme_hide_website_buttons
-    )
+def setup_my_func(app, config):
+    # We can't set this in the theme.conf, cos we want it to be a non-string type
+    config.html_theme_options.setdefault('navbar_links', [{'href': '/index.html', 'text': 'Documentation'}])
 
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app: Sphinx):
-    app.add_config_value(
-        'sphinx_airflow_theme_navbar_links',
-        default=[
-            {'href': '/docs/', 'text': 'Documentation'}
-        ],
-        rebuild='html'
-    )
-    app.add_config_value(
-        'sphinx_airflow_theme_hide_website_buttons',
-        default=False,
-        rebuild='html',
-        types=[bool]
-    )
-
     app.add_html_theme('sphinx_airflow_theme', path.abspath(path.dirname(__file__)))
     app.add_stylesheet('_gen/css/main-custom.min.css')
-    app.connect("html-page-context", setup_my_func)
+    app.connect("config-inited", setup_my_func)

--- a/sphinx_airflow_theme/sphinx_airflow_theme/header.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/header.html
@@ -55,14 +55,14 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    {% for link in navbar_links %}
+                    {% for link in theme_navbar_links %}
                         <a class="navbar__text-link" href="{{ link.href }}">
                             {{ link.text }}
                         </a>
                     {% endfor %}
                 </div>
 
-                {% if not hide_website_buttons %}
+                {% if not theme_hide_website_buttons %}
                 <a href="/docs/stable/start.html">
                     <button class="btn-filled bodytext__medium--white">Install</button>
                 </a>
@@ -117,7 +117,7 @@
                         {% endfor %}
 
                     </div>
-                    {% if not hide_website_buttons %}
+                    {% if not theme_hide_website_buttons %}
                     <a href="/install/">
 
                         <button id="" class="btn-filled bodytext__medium--white ">Install</button>

--- a/sphinx_airflow_theme/sphinx_airflow_theme/theme.conf
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/theme.conf
@@ -6,3 +6,6 @@ pygments_style = default
 [options]
 canonical_url =
 analytics_id =
+# Default set by python code, need to list this here to avoid warning from Sphinx
+navbar_links =
+hide_website_buttons = false


### PR DESCRIPTION
Rather than using custom config properties, and then putting them in to
the theme context, this uses Sphinx's built in mechanism that
automatically exposes every option in `theme.conf` with a `theme_`
prefix.

This commit will make a bit more sense in a second as I am going to add a few more options in here.

I will follow up with a PR to update apache-airflow too.