### PR TITLE
Show hidden ToCs in the sidebar.

### DIFF
--- a/sphinx_airflow_theme/README.md
+++ b/sphinx_airflow_theme/README.md
@@ -84,6 +84,11 @@ html_theme_options = {
 }
 ```
 
+## `sidebar_collapse`
+## `sidebar_includehidden`
+
+Controls the ToC display in the sidebar. See https://www.sphinx-doc.org/en/master/templating.html#toctree for more info
+
 # Theme's source files
 
  - `<ROOT DIRECTORY>/sphinx_airflow_theme/sphinx_airflow_theme` - HTML files

--- a/sphinx_airflow_theme/sphinx_airflow_theme/globaltoc.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/globaltoc.html
@@ -19,7 +19,7 @@
 #}
 
 <div class="toctree" role="navigation" aria-label="main navigation">
-    {{ toctree() }}
+    {{ toctree(includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse) }}
 </div>
 
 <style type="text/css">

--- a/sphinx_airflow_theme/sphinx_airflow_theme/theme.conf
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/theme.conf
@@ -9,3 +9,5 @@ analytics_id =
 # Default set by python code, need to list this here to avoid warning from Sphinx
 navbar_links =
 hide_website_buttons = false
+sidebar_collapse = true
+sidebar_includehidden = true


### PR DESCRIPTION
Relates to apache/airflow#12554

This config, naming, and default behaviour was taken from the
"alabaster" sphinx theme (the default HTML theme)

I have tested that with these default settings, we can put back the `:hidden:` and the sidebar is still populated.