### PR TITLE
[DOC] fix doc reference to apache Kylin

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -29,7 +29,7 @@ Providers packages include integrations with third party integrations. They are 
 
   <li><a href="/docs/apache-airflow-providers-apache-hive/stable/index.html"><code>Apache Hive</code></a></li>
 
-  <li><a href="/docs/apache-airflow-providers-apache-kylin/stable/index.html"><code>Apache Hive</code></a></li>
+  <li><a href="/docs/apache-airflow-providers-apache-kylin/stable/index.html"><code>Apache Kylin</code></a></li>
 
   <li><a href="/docs/apache-airflow-providers-apache-livy/stable/index.html"><code>Apache Livy</code></a></li>
 


### PR DESCRIPTION
[DOC] fix doc reference to apache Kylin on
https://airflow.apache.org/docs/