### PR TITLE
Switch to Apache-owned GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 🐍 Install Python depedencies
         run: pip install -r requirements.txt
       - name: 🔎 Lint
-        uses: apache/pre-commit-action@0764670bf370aab253130d534e1eda7ff497dc60  # v2.0.0
+        uses: apache/airflow-pre-commit-action@0764670bf370aab253130d534e1eda7ff497dc60  # v2.0.0
       - name: 🔧 Build site
         run: ./site.sh build-site
       - name: 🐅 Optimize artifacts
@@ -62,7 +62,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: 🚀 Deploy website on asf-site branch
-        uses: apache/JamesIves-github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
+        uses: apache/airflow-JamesIves-github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
         if: ${{ github.event_name == 'push' }}
         with:
           BRANCH: asf-site  # The branch the action should deploy to.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 🐍 Install Python depedencies
         run: pip install -r requirements.txt
       - name: 🔎 Lint
-        uses: pre-commit/action@0764670bf370aab253130d534e1eda7ff497dc60  # v2.0.0
+        uses: apache/pre-commit-action@0764670bf370aab253130d534e1eda7ff497dc60  # v2.0.0
       - name: 🔧 Build site
         run: ./site.sh build-site
       - name: 🐅 Optimize artifacts
@@ -62,7 +62,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: 🚀 Deploy website on asf-site branch
-        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
+        uses: apache/JamesIves-github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
         if: ${{ github.event_name == 'push' }}
         with:
           BRANCH: asf-site  # The branch the action should deploy to.


### PR DESCRIPTION
There was a change in Policy of ASF that only "Made by GitHub"
actions and actions residing in Apache-owned repositories
are allowed to be used for ASF projects. This was in
response to a security incident.

More details:

Policy:

* https://infra.apache.org/github-actions-secrets.html

Discussion builds@apache.org:

* https://lists.apache.org/thread.html/r435c45dfc28ec74e28314aa9db8a216a2b45ff7f27b15932035d3f65%40%3Cbuilds.apache.org%3E

Discussion users@infra.apache.org:

* https://lists.apache.org/thread.html/r900f8f9a874006ed8121bdc901a0d1acccbb340882c1f94dad61a5e9%40%3Cusers.infra.apache.org%3E