### PR TITLE
Add Tel Aviv meetup group to meetup links

### DIFF
--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -7,6 +7,13 @@
     "url": "https://www.meetup.com/Amsterdam-Airflow-meetup/"
   },
   {
+    "city": "Tel Aviv",
+    "country": "Israel",
+    "date": "",
+    "members": 38,
+    "url": "https://www.meetup.com/tel-aviv-apache-airflow-meetup/"
+  },
+  {
     "city": "San Francisco",
     "country": "USA",
     "date": "",


### PR DESCRIPTION
Added Tel aviv Apache airflow meetup group.
https://www.meetup.com/tel-aviv-apache-airflow-meetup/

