### PR TITLE
Removed the outline around list items in Community tab.

### DIFF
--- a/landing-pages/site/assets/scss/_accordion.scss
+++ b/landing-pages/site/assets/scss/_accordion.scss
@@ -31,6 +31,7 @@ details.accordion {
   summary {
     position: relative;
     display: block;
+    outline: none;
   }
 
   summary::-webkit-details-marker {


### PR DESCRIPTION
In the community tab when any of the items is selected then a black outline comes around that item. So I have removed that outline in the class "summary".

Before:-
![Screenshot (2)](https://user-images.githubusercontent.com/68113233/104844482-7bf84780-58f6-11eb-8f95-e34b5f6fce43.png)

After:-
![Screenshot (3)](https://user-images.githubusercontent.com/68113233/104844492-89153680-58f6-11eb-90a4-b484712076e1.png)
