### PR TITLE
Update copyright year dynamically in the footer

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/footer.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/footer.html
@@ -105,7 +105,7 @@
     </div>
     <div class="footer-section footer-section__policies-section">
         <div class="footer-section">
-            <span>© The Apache Software Foundation 2019</span>
+            <span>© The Apache Software Foundation <script>document.write(new Date().getFullYear())</script></span>
             <div class="footer-section__policies-section--policies">
 
                 <a href="https://www.apache.org/licenses/" class="footer-section__policies-section--policy-item">


### PR DESCRIPTION
In https://airflow.apache.org/docs/apache-airflow/stable/tutorial.html, the website still shows 2019.

![image](https://user-images.githubusercontent.com/53068787/115447332-032ac380-a236-11eb-9acd-e95e4b80f5d5.png)
