### PR TITLE
Replaced versions in published 2.0.2 documentation

### DIFF
--- a/docs-archive/apache-airflow/2.0.2/_sources/extra-packages-ref.rst.txt
+++ b/docs-archive/apache-airflow/2.0.2/_sources/extra-packages-ref.rst.txt
@@ -84,14 +84,14 @@ For example the below command will install:
   * apache-airflow-providers-google
   * apache-airflow-providers-apache-spark
 
-with a consistent set of dependencies based on constraint files provided by Airflow  Community at the time 2.0.1 version was released.
+with a consistent set of dependencies based on constraint files provided by Airflow  Community at the time 2.0.2 version was released.
 
 .. code-block:: bash
 
-    pip install apache-airflow[google,amazon,apache.spark]==2.0.1 \
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.1/constraints-3.6.txt"
+    pip install apache-airflow[google,amazon,apache.spark]==2.0.2 \
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.6.txt"
 
-Note, that this will install providers in the versions that were released at the time of Airflow 2.0.1 release. You can later
+Note, that this will install providers in the versions that were released at the time of Airflow 2.0.2 release. You can later
 upgrade those providers manually if you want to use latest versions of the providers.
 
 

--- a/docs-archive/apache-airflow/2.0.2/_sources/installation.rst.txt
+++ b/docs-archive/apache-airflow/2.0.2/_sources/installation.rst.txt
@@ -162,7 +162,7 @@ not work or will produce unusable Airflow installation.
 In order to have repeatable installation, starting from **Airflow 1.10.10** and updated in
 **Airflow 1.10.13** we also keep a set of "known-to-be-working" constraint files in the
 ``constraints-master``, ``constraints-2-0`` and ``constraints-1-10`` orphan branches and then we create tag
-for each released version e.g. ``constraints-2.0.1``. This way, when we keep a tested and working set of dependencies.
+for each released version e.g. ``constraints-2.0.2``. This way, when we keep a tested and working set of dependencies.
 
 Those "known-to-be-working" constraints are per major/minor Python version. You can use them as constraint
 files when installing Airflow from PyPI. Note that you have to specify correct Airflow version
@@ -176,7 +176,7 @@ You can create the URL to the file substituting the variables in the template be
 
 where:
 
-- ``AIRFLOW_VERSION`` - Airflow version (e.g. ``2.0.1``) or ``master``, ``2-0``, ``1-10`` for latest development version
+- ``AIRFLOW_VERSION`` - Airflow version (e.g. ``2.0.2``) or ``master``, ``2-0``, ``1-10`` for latest development version
 - ``PYTHON_VERSION`` Python version e.g. ``3.8``, ``3.7``
 
 There is also a no-providers constraint file, which contains just constraints required to install Airflow core. This allows
@@ -202,7 +202,7 @@ postgres and google provider, as well as ``async`` extra.
 
 .. code-block:: bash
 
-    AIRFLOW_VERSION=2.0.1
+    AIRFLOW_VERSION=2.0.2
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
     pip install "apache-airflow[async,postgres,google]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
@@ -220,7 +220,7 @@ being installed.
 
 .. code-block:: bash
 
-    AIRFLOW_VERSION=2.0.1
+    AIRFLOW_VERSION=2.0.2
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
     pip install --upgrade "apache-airflow[postgres,google]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
@@ -256,11 +256,11 @@ If you don't want to install any extra providers, initially you can use the comm
 
 .. code-block:: bash
 
-    AIRFLOW_VERSION=2.0.1
+    AIRFLOW_VERSION=2.0.2
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     # For example: 3.6
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-no-providers-${PYTHON_VERSION}.txt"
-    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-no-providers-2.0.1/constraints-3.6.txt
+    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-no-providers-2.0.2/constraints-3.6.txt
     pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
 

--- a/docs-archive/apache-airflow/2.0.2/_sources/start/local.rst.txt
+++ b/docs-archive/apache-airflow/2.0.2/_sources/start/local.rst.txt
@@ -52,11 +52,11 @@ constraint files to enable reproducible installation, so using ``pip`` and const
     # (optional)
     export AIRFLOW_HOME=~/airflow
 
-    AIRFLOW_VERSION=2.0.1
+    AIRFLOW_VERSION=2.0.2
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     # For example: 3.6
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
-    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.0.1/constraints-3.6.txt
+    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.6.txt
     pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
     # initialize the database

--- a/docs-archive/apache-airflow/2.0.2/extra-packages-ref.html
+++ b/docs-archive/apache-airflow/2.0.2/extra-packages-ref.html
@@ -760,12 +760,12 @@ for first time installation where you want to repeatably install version of depe
 <li><p>apache-airflow-providers-apache-spark</p></li>
 </ul>
 </div></blockquote>
-<p>with a consistent set of dependencies based on constraint files provided by Airflow  Community at the time 2.0.1 version was released.</p>
+<p>with a consistent set of dependencies based on constraint files provided by Airflow  Community at the time 2.0.2 version was released.</p>
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip install apache-airflow<span class="o">[</span>google,amazon,apache.spark<span class="o">]==</span><span class="m">2</span>.0.1 <span class="se">\</span>
-  --constraint <span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.0.1/constraints-3.6.txt&quot;</span>
+  --constraint <span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.6.txt&quot;</span>
 </pre></div>
 </div>
-<p>Note, that this will install providers in the versions that were released at the time of Airflow 2.0.1 release. You can later
+<p>Note, that this will install providers in the versions that were released at the time of Airflow 2.0.2 release. You can later
 upgrade those providers manually if you want to use latest versions of the providers.</p>
 <div class="section" id="apache-software-extras">
 <h3>Apache Software extras<a class="headerlink" href="#apache-software-extras" title="Permalink to this headline">¶</a></h3>

--- a/docs-archive/apache-airflow/2.0.2/installation.html
+++ b/docs-archive/apache-airflow/2.0.2/installation.html
@@ -802,7 +802,7 @@ not work or will produce unusable Airflow installation.</p>
 <p>In order to have repeatable installation, starting from <strong>Airflow 1.10.10</strong> and updated in
 <strong>Airflow 1.10.13</strong> we also keep a set of &quot;known-to-be-working&quot; constraint files in the
 <code class="docutils literal notranslate"><span class="pre">constraints-master</span></code>, <code class="docutils literal notranslate"><span class="pre">constraints-2-0</span></code> and <code class="docutils literal notranslate"><span class="pre">constraints-1-10</span></code> orphan branches and then we create tag
-for each released version e.g. <code class="docutils literal notranslate"><span class="pre">constraints-2.0.1</span></code>. This way, when we keep a tested and working set of dependencies.</p>
+for each released version e.g. <code class="docutils literal notranslate"><span class="pre">constraints-2.0.2</span></code>. This way, when we keep a tested and working set of dependencies.</p>
 <p>Those &quot;known-to-be-working&quot; constraints are per major/minor Python version. You can use them as constraint
 files when installing Airflow from PyPI. Note that you have to specify correct Airflow version
 and Python versions in the URL.</p>
@@ -812,7 +812,7 @@ and Python versions in the URL.</p>
 </div>
 <p>where:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">AIRFLOW_VERSION</span></code> - Airflow version (e.g. <code class="docutils literal notranslate"><span class="pre">2.0.1</span></code>) or <code class="docutils literal notranslate"><span class="pre">master</span></code>, <code class="docutils literal notranslate"><span class="pre">2-0</span></code>, <code class="docutils literal notranslate"><span class="pre">1-10</span></code> for latest development version</p></li>
+<li><p><code class="docutils literal notranslate"><span class="pre">AIRFLOW_VERSION</span></code> - Airflow version (e.g. <code class="docutils literal notranslate"><span class="pre">2.0.2</span></code>) or <code class="docutils literal notranslate"><span class="pre">master</span></code>, <code class="docutils literal notranslate"><span class="pre">2-0</span></code>, <code class="docutils literal notranslate"><span class="pre">1-10</span></code> for latest development version</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">PYTHON_VERSION</span></code> Python version e.g. <code class="docutils literal notranslate"><span class="pre">3.8</span></code>, <code class="docutils literal notranslate"><span class="pre">3.7</span></code></p></li>
 </ul>
 <p>There is also a no-providers constraint file, which contains just constraints required to install Airflow core. This allows
@@ -873,7 +873,7 @@ pip install <span class="s2">&quot;apache-airflow-providers-google&quot;</span> 
 <span class="nv">PYTHON_VERSION</span><span class="o">=</span><span class="s2">&quot;</span><span class="k">$(</span>python --version <span class="p">|</span> cut -d <span class="s2">&quot; &quot;</span> -f <span class="m">2</span> <span class="p">|</span> cut -d <span class="s2">&quot;.&quot;</span> -f <span class="m">1</span>-2<span class="k">)</span><span class="s2">&quot;</span>
 <span class="c1"># For example: 3.6</span>
 <span class="nv">CONSTRAINT_URL</span><span class="o">=</span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-</span><span class="si">${</span><span class="nv">AIRFLOW_VERSION</span><span class="si">}</span><span class="s2">/constraints-no-providers-</span><span class="si">${</span><span class="nv">PYTHON_VERSION</span><span class="si">}</span><span class="s2">.txt&quot;</span>
-<span class="c1"># For example: https://raw.githubusercontent.com/apache/airflow/constraints-no-providers-2.0.1/constraints-3.6.txt</span>
+<span class="c1"># For example: https://raw.githubusercontent.com/apache/airflow/constraints-no-providers-2.0.2/constraints-3.6.txt</span>
 pip install <span class="s2">&quot;apache-airflow==</span><span class="si">${</span><span class="nv">AIRFLOW_VERSION</span><span class="si">}</span><span class="s2">&quot;</span> --constraint <span class="s2">&quot;</span><span class="si">${</span><span class="nv">CONSTRAINT_URL</span><span class="si">}</span><span class="s2">&quot;</span>
 </pre></div>
 </div>

--- a/docs-archive/apache-airflow/2.0.2/start/local.html
+++ b/docs-archive/apache-airflow/2.0.2/start/local.html
@@ -678,7 +678,7 @@ constraint files to enable reproducible installation, so using <code class="docu
 <span class="nv">PYTHON_VERSION</span><span class="o">=</span><span class="s2">&quot;</span><span class="k">$(</span>python --version <span class="p">|</span> cut -d <span class="s2">&quot; &quot;</span> -f <span class="m">2</span> <span class="p">|</span> cut -d <span class="s2">&quot;.&quot;</span> -f <span class="m">1</span>-2<span class="k">)</span><span class="s2">&quot;</span>
 <span class="c1"># For example: 3.6</span>
 <span class="nv">CONSTRAINT_URL</span><span class="o">=</span><span class="s2">&quot;https://raw.githubusercontent.com/apache/airflow/constraints-</span><span class="si">${</span><span class="nv">AIRFLOW_VERSION</span><span class="si">}</span><span class="s2">/constraints-</span><span class="si">${</span><span class="nv">PYTHON_VERSION</span><span class="si">}</span><span class="s2">.txt&quot;</span>
-<span class="c1"># For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.0.1/constraints-3.6.txt</span>
+<span class="c1"># For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.6.txt</span>
 pip install <span class="s2">&quot;apache-airflow==</span><span class="si">${</span><span class="nv">AIRFLOW_VERSION</span><span class="si">}</span><span class="s2">&quot;</span> --constraint <span class="s2">&quot;</span><span class="si">${</span><span class="nv">CONSTRAINT_URL</span><span class="si">}</span><span class="s2">&quot;</span>
 
 <span class="c1"># initialize the database</span>


### PR DESCRIPTION
Related to https://github.com/apache/airflow/pull/15484
and https://github.com/apache/airflow/pull/15459

The docs were generated before the version was updated.