### PR TITLE
Add Helm Chart's index.yaml

### DIFF
--- a/landing-pages/site/static/index.yaml
+++ b/landing-pages/site/static/index.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 apiVersion: v1
 entries:
   airflow:

--- a/landing-pages/site/static/index.yaml
+++ b/landing-pages/site/static/index.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+entries:
+  airflow:
+  - apiVersion: v1
+    appVersion: 2.0.2
+    created: "2021-05-16T02:11:02.558176+01:00"
+    dependencies:
+    - condition: postgresql.enabled
+      name: postgresql
+      repository: https://charts.bitnami.com/bitnami
+      version: 6.3.12
+    description: Helm chart to deploy Apache Airflow, a platform to programmatically author, schedule, and monitor workflows
+    digest: 6cd3f13fc93d60424a771a1a8a4121c4439f7b6b48fab946436da0ab70d5a507
+    home: https://airflow.apache.org/
+    icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
+    keywords:
+    - apache
+    - airflow
+    - workflow
+    - scheduler
+    maintainers:
+    - email: dev@airflow.apache.org
+      name: Apache Airflow PMC
+    name: airflow
+    sources:
+    - https://github.com/apache/airflow
+    urls:
+    - https://downloads.apache.org/airflow/helm-chart/1.0.0/airflow-1.0.0.tgz
+    version: 1.0.0
+generated: "2021-05-16T02:11:02.548452+01:00"

--- a/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
@@ -36,5 +36,5 @@ def setup_my_func(app, config):
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app: Sphinx):
     app.add_html_theme('sphinx_airflow_theme', path.abspath(path.dirname(__file__)))
-    app.add_stylesheet('_gen/css/main-custom.min.css')
+    app.add_css_file('_gen/css/main-custom.min.css')
     app.connect("config-inited", setup_my_func)


### PR DESCRIPTION
Add index.yaml for convenience of downloading the Helm Chart

This will allow the following:

```
helm repo add apache-airflow https://airflow.apache.org/
```

Mailing List Thread:
https://lists.apache.org/thread.html/r865f041e491a2a7a52e17784abf0d0f2e35c3bac5ae8a05927285558%40%3Cdev.airflow.apache.org%3E