### PR TITLE
Set __version__ of sphinx_airflow_theme module correctly

### DIFF
--- a/sphinx_airflow_theme/setup.cfg
+++ b/sphinx_airflow_theme/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: sphinx_airflow_theme.__version__

--- a/sphinx_airflow_theme/setup.py
+++ b/sphinx_airflow_theme/setup.py
@@ -38,7 +38,6 @@ with open('README.md', encoding='utf-8') as file:
 
 setup(
     name='sphinx_airflow_theme',
-    version='0.0.4',
     url='https://github.com/apache/airflow-site/tree/aip-11',
     license='Apache License 2.0',
     author='Apache Software Foundation',

--- a/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
@@ -18,7 +18,7 @@
 from os import path
 from sphinx.application import Sphinx
 
-__version__ = '0.0.2'
+__version__ = '0.0.4'
 __version_full__ = __version__
 
 


### PR DESCRIPTION
Using this feature of setuptools 46.4.0+ we only need to specify it
once, and don't have to handle parsing it either