### PR TITLE
Switch publishing process from gitwcsub to gh-pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,3 +34,5 @@ github:
     master:
       required_pull_request_reviews:
         required_approving_review_count: 1
+
+  ghp_branch: gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: apache/airflow-JamesIves-github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
         if: ${{ github.event_name == 'push' }}
         with:
-          BRANCH: asf-site  # The branch the action should deploy to.
+          BRANCH: gh-pages  # The branch the action should deploy to.
           FOLDER: dist  # The folder the action should deploy.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLEAN: true  # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
Hello,

We need to migrate to a new building process because in order to simplify apache web site publishing services and improve self-serve for projects and stability of deployments, infra will be turning off the old 'gitwcsub' method of publishing git websites. All websites should switch to our self-serve method of publishing via the .asf.yaml meta-file. They aim to turn off `gitwcsub` around July 1st.

More info: https://lists.apache.org/thread.html/raf30ca1c77b81bc8c535c53b7aff38e1ff3c755ce84f4a40a6d8ad53%40%3Cusers.infra.apache.org%3E

I created `apache/gh-pages` to keep a history of changes. 
Best regards,
Kamil Breguła