### PR TITLE
Add python client link in documentation

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -182,3 +182,8 @@ Airflow has an official Helm Chart that will help you set up your own Airflow on
         }
     }
 </style>
+
+## [Python API Client](https://github.com/apache/airflow-client-python)
+
+Airflow releases official Python API client that can be used to easily interact with Airflow REST API from Python code.
+[See the client repository](https://github.com/apache/airflow-client-python)


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow-client-python/issues/26