### PR TITLE
Manually remove banner from pre-built docs files

### DIFF
--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/hooks/airbyte/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/hooks/airbyte/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/operators/airbyte/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/operators/airbyte/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/operators/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/sensors/airbyte/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/sensors/airbyte/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_api/airflow/providers/airbyte/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/example_dags/example_airbyte_trigger_job.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/example_dags/example_airbyte_trigger_job.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/hooks/airbyte.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/hooks/airbyte.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/operators/airbyte.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/operators/airbyte.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/sensors/airbyte.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/airflow/providers/airbyte/sensors/airbyte.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/connections.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/connections.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/operators/airbyte.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/operators/airbyte.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/exceptions/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/exceptions/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/athena/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/athena/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/aws_dynamodb/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/aws_dynamodb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/base_aws/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/base_aws/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/batch_client/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/batch_client/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/batch_waiters/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/batch_waiters/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/cloud_formation/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/cloud_formation/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/datasync/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/datasync/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/dms/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/dms/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/dynamodb/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/dynamodb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/ec2/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/ec2/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/elasticache_replication_group/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/elasticache_replication_group/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/emr/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/emr/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glacier/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glacier/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glue/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glue/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glue_catalog/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glue_catalog/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glue_crawler/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/glue_crawler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/kinesis/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/kinesis/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/lambda_function/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/lambda_function/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/logs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/logs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/redshift/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/redshift/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/sagemaker/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/sagemaker/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/secrets_manager/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/secrets_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/ses/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/ses/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/sns/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/sns/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/sqs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/sqs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/step_function/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/hooks/step_function/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/log/cloudwatch_task_handler/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/log/cloudwatch_task_handler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/log/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/log/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/log/s3_task_handler/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/log/s3_task_handler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/athena/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/athena/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/batch/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/batch/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/cloud_formation/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/cloud_formation/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/datasync/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/datasync/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_create_task/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_create_task/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_delete_task/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_delete_task/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_describe_tasks/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_describe_tasks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_start_task/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_start_task/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_stop_task/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/dms_stop_task/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/ec2_start_instance/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/ec2_start_instance/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/ec2_stop_instance/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/ec2_stop_instance/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/ecs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/ecs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_add_steps/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_add_steps/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_create_job_flow/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_create_job_flow/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_modify_cluster/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_modify_cluster/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_terminate_job_flow/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/emr_terminate_job_flow/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/glacier/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/glacier/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/glue/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/glue/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/glue_crawler/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/glue_crawler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_bucket/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_bucket/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_bucket_tagging/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_bucket_tagging/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_copy_object/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_copy_object/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_delete_objects/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_delete_objects/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_file_transform/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_file_transform/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_list/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/s3_list/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_base/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_base/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_endpoint/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_endpoint/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_model/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_model/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_processing/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_processing/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_training/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_training/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_transform/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_transform/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_tuning/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sagemaker_tuning/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sns/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sns/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sqs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/sqs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/step_function_get_execution_output/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/step_function_get_execution_output/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/step_function_start_execution/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/operators/step_function_start_execution/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/secrets/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/secrets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/secrets/secrets_manager/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/secrets/secrets_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/secrets/systems_manager/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/secrets/systems_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/athena/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/athena/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/cloud_formation/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/cloud_formation/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/dms_task/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/dms_task/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/ec2_instance_state/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/ec2_instance_state/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/emr_base/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/emr_base/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/emr_job_flow/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/emr_job_flow/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/emr_step/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/emr_step/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glacier/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glacier/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glue/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glue/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glue_catalog_partition/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glue_catalog_partition/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glue_crawler/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/glue_crawler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/redshift/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/redshift/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/s3_key/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/s3_key/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/s3_keys_unchanged/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/s3_keys_unchanged/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/s3_prefix/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/s3_prefix/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_base/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_base/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_endpoint/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_endpoint/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_training/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_training/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_transform/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_transform/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_tuning/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sagemaker_tuning/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sqs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/sqs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/step_function_execution/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/sensors/step_function_execution/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/dynamodb_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/dynamodb_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/exasol_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/exasol_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/ftp_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/ftp_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/gcs_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/gcs_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/glacier_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/glacier_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/google_api_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/google_api_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/hive_to_dynamodb/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/hive_to_dynamodb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/mongo_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/mongo_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/mysql_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/mysql_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/redshift_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/redshift_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/s3_to_ftp/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/s3_to_ftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/s3_to_redshift/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/s3_to_redshift/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/s3_to_sftp/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/s3_to_sftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/salesforce_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/salesforce_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/sftp_to_s3/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/transfers/sftp_to_s3/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/utils/emailer/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/utils/emailer/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/utils/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/utils/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/utils/redshift/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/aws/utils/redshift/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_api/airflow/providers/amazon/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_datasync_1.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_datasync_1.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_datasync_2.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_datasync_2.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_imap_attachment_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_imap_attachment_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_bucket.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_bucket.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_bucket_tagging.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_bucket_tagging.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_to_sftp.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_s3_to_sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_sftp_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/example_dags/example_sftp_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/exceptions.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/exceptions.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/athena.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/athena.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/base_aws.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/base_aws.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/batch_client.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/batch_client.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/batch_waiters.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/batch_waiters.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/cloud_formation.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/cloud_formation.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/datasync.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/datasync.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/dms.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/dms.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/dynamodb.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/dynamodb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/ec2.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/ec2.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/elasticache_replication_group.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/elasticache_replication_group.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/emr.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/emr.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glacier.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glacier.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glue.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glue.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glue_catalog.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glue_catalog.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glue_crawler.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/glue_crawler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/kinesis.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/kinesis.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/lambda_function.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/lambda_function.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/logs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/logs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/redshift.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/redshift.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/sagemaker.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/sagemaker.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/secrets_manager.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/secrets_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/ses.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/ses.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/sns.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/sns.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/sqs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/sqs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/step_function.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/hooks/step_function.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/log/cloudwatch_task_handler.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/log/cloudwatch_task_handler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/log/s3_task_handler.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/log/s3_task_handler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/athena.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/athena.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/batch.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/batch.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/cloud_formation.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/cloud_formation.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/datasync.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/datasync.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_create_task.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_create_task.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_delete_task.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_delete_task.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_describe_tasks.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_describe_tasks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_start_task.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_start_task.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_stop_task.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/dms_stop_task.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/ec2_start_instance.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/ec2_start_instance.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/ec2_stop_instance.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/ec2_stop_instance.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/ecs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/ecs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_add_steps.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_add_steps.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_create_job_flow.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_create_job_flow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_modify_cluster.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_modify_cluster.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/glacier.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/glacier.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/glue.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/glue.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/glue_crawler.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/glue_crawler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_bucket.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_bucket.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_bucket_tagging.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_bucket_tagging.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_copy_object.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_copy_object.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_delete_objects.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_delete_objects.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_file_transform.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_file_transform.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_list.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/s3_list.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_base.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_base.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_endpoint.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_endpoint.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_endpoint_config.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_model.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_model.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_processing.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_processing.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_training.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_training.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_transform.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_transform.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_tuning.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sagemaker_tuning.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sns.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sns.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sqs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/sqs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/step_function_get_execution_output.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/step_function_get_execution_output.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/step_function_start_execution.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/operators/step_function_start_execution.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/secrets/secrets_manager.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/secrets/secrets_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/secrets/systems_manager.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/secrets/systems_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/athena.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/athena.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/cloud_formation.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/cloud_formation.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/dms_task.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/dms_task.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/ec2_instance_state.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/ec2_instance_state.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/emr_base.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/emr_base.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/emr_job_flow.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/emr_job_flow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/emr_step.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/emr_step.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glacier.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glacier.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glue.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glue.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glue_catalog_partition.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glue_catalog_partition.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glue_crawler.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/glue_crawler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/redshift.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/redshift.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/s3_key.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/s3_key.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/s3_keys_unchanged.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/s3_keys_unchanged.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/s3_prefix.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/s3_prefix.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_base.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_base.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_endpoint.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_endpoint.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_training.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_training.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_transform.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_transform.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_tuning.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sagemaker_tuning.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sqs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/sqs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/step_function_execution.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/sensors/step_function_execution.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/exasol_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/exasol_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/ftp_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/ftp_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/gcs_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/gcs_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/glacier_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/glacier_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/google_api_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/google_api_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/mongo_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/mongo_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/mysql_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/mysql_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/redshift_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/redshift_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/s3_to_ftp.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/s3_to_ftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/s3_to_redshift.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/s3_to_redshift.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/s3_to_sftp.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/s3_to_sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/salesforce_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/salesforce_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/sftp_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/transfers/sftp_to_s3.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/utils/emailer.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/utils/emailer.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/utils/redshift.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/airflow/providers/amazon/aws/utils/redshift.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/connections/aws.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/connections/aws.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/logging/cloud-watch-task-handlers.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/logging/cloud-watch-task-handlers.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/logging/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/logging/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/logging/s3-task-handler.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/logging/s3-task-handler.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/datasync.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/datasync.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/dms.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/dms.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/ecs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/ecs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/emr.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/emr.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/glacier.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/glacier.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/google_api_to_s3_transfer.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/google_api_to_s3_transfer.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/imap_attachment_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/imap_attachment_to_s3.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/s3.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/s3_to_redshift.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/s3_to_redshift.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/salesforce_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/salesforce_to_s3.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/glacier_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/glacier_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/s3_to_sftp.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/s3_to_sftp.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/sftp_to_s3.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/operators/transfer/sftp_to_s3.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/secrets-backends/aws-secrets-manager.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/secrets-backends/aws-secrets-manager.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/secrets-backends/aws-ssm-parameter-store.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/secrets-backends/aws-ssm-parameter-store.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/secrets-backends/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/secrets-backends/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/hooks/beam/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/hooks/beam/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/operators/beam/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/operators/beam/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_api/airflow/providers/apache/beam/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/airflow/providers/apache/beam/example_dags/example_beam.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/airflow/providers/apache/beam/example_dags/example_beam.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/airflow/providers/apache/beam/hooks/beam.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/airflow/providers/apache/beam/hooks/beam.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/airflow/providers/apache/beam/operators/beam.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/airflow/providers/apache/beam/operators/beam.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/hooks/cassandra/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/hooks/cassandra/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/sensors/record/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/sensors/record/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/sensors/table/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_api/airflow/providers/apache/cassandra/sensors/table/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/hooks/cassandra.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/hooks/cassandra.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/sensors/record.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/sensors/record.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/sensors/table.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/airflow/providers/apache/cassandra/sensors/table.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/connections/cassandra.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/connections/cassandra.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/hooks/drill/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/hooks/drill/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/operators/drill/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/operators/drill/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_api/airflow/providers/apache/drill/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/airflow/providers/apache/drill/example_dags/example_drill_dag.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/airflow/providers/apache/drill/example_dags/example_drill_dag.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/airflow/providers/apache/drill/hooks/drill.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/airflow/providers/apache/drill/hooks/drill.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/airflow/providers/apache/drill/operators/drill.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/airflow/providers/apache/drill/operators/drill.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/connections/drill.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/connections/drill.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/hooks/druid/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/hooks/druid/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/operators/druid/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/operators/druid/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/operators/druid_check/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/operators/druid_check/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/transfers/hive_to_druid/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/transfers/hive_to_druid/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_api/airflow/providers/apache/druid/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/hooks/druid.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/hooks/druid.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/operators/druid.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/operators/druid.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/operators/druid_check.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/operators/druid_check.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/transfers/hive_to_druid.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/airflow/providers/apache/druid/transfers/hive_to_druid.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.1/search.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.1/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/hooks/hdfs/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/hooks/hdfs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/hooks/webhdfs/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/hooks/webhdfs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/sensors/hdfs/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/sensors/hdfs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/sensors/web_hdfs/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_api/airflow/providers/apache/hdfs/sensors/web_hdfs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/hooks/hdfs.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/hooks/hdfs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/hooks/webhdfs.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/hooks/webhdfs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/sensors/hdfs.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/sensors/hdfs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/sensors/web_hdfs.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/airflow/providers/apache/hdfs/sensors/web_hdfs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/connections.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/connections.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/hooks/hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/hooks/hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/operators/hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/operators/hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/operators/hive_stats/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/operators/hive_stats/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/hive_partition/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/hive_partition/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/metastore_partition/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/metastore_partition/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/named_hive_partition/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/sensors/named_hive_partition/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/hive_to_mysql/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/hive_to_mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/hive_to_samba/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/hive_to_samba/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/mssql_to_hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/mssql_to_hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/mysql_to_hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/mysql_to_hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/s3_to_hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/s3_to_hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/vertica_to_hive/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_api/airflow/providers/apache/hive/transfers/vertica_to_hive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/operators/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/operators/hive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/operators/hive_stats.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/operators/hive_stats.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/sensors/hive_partition.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/sensors/hive_partition.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/sensors/metastore_partition.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/sensors/metastore_partition.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/sensors/named_hive_partition.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/sensors/named_hive_partition.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/hive_to_mysql.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/hive_to_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/hive_to_samba.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/hive_to_samba.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/mssql_to_hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/mssql_to_hive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/mysql_to_hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/mysql_to_hive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/s3_to_hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/s3_to_hive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/vertica_to_hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/transfers/vertica_to_hive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hive_cli.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hive_cli.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hive_metastore.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hiveserver2.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/search.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/hooks/kylin/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/hooks/kylin/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/operators/kylin_cube/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_api/airflow/providers/apache/kylin/operators/kylin_cube/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_modules/airflow/providers/apache/kylin/hooks/kylin.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_modules/airflow/providers/apache/kylin/hooks/kylin.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_modules/airflow/providers/apache/kylin/operators/kylin_cube.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_modules/airflow/providers/apache/kylin/operators/kylin_cube.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/hooks/livy/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/hooks/livy/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/operators/livy/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/operators/livy/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/sensors/livy/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_api/airflow/providers/apache/livy/sensors/livy/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/airflow/providers/apache/livy/hooks/livy.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/airflow/providers/apache/livy/hooks/livy.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/airflow/providers/apache/livy/operators/livy.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/airflow/providers/apache/livy/operators/livy.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/airflow/providers/apache/livy/sensors/livy.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/airflow/providers/apache/livy/sensors/livy.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/hooks/pig/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/hooks/pig/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/operators/pig/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_api/airflow/providers/apache/pig/operators/pig/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_modules/airflow/providers/apache/pig/hooks/pig.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_modules/airflow/providers/apache/pig/hooks/pig.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_modules/airflow/providers/apache/pig/operators/pig.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_modules/airflow/providers/apache/pig/operators/pig.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_api/airflow/providers/apache/pinot/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_api/airflow/providers/apache/pinot/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_api/airflow/providers/apache/pinot/hooks/pinot/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_api/airflow/providers/apache/pinot/hooks/pinot/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_api/airflow/providers/apache/pinot/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_api/airflow/providers/apache/pinot/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_modules/airflow/providers/apache/pinot/hooks/pinot.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_modules/airflow/providers/apache/pinot/hooks/pinot.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_jdbc/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_jdbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_jdbc_script/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_jdbc_script/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_sql/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_sql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_submit/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/hooks/spark_submit/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/spark_jdbc/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/spark_jdbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/spark_sql/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/spark_sql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/spark_submit/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_api/airflow/providers/apache/spark/operators/spark_submit/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/example_dags/example_spark_dag.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/example_dags/example_spark_dag.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_jdbc.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_jdbc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_jdbc_script.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_jdbc_script.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_sql.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_sql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_submit.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/hooks/spark_submit.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/operators/spark_jdbc.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/operators/spark_jdbc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/operators/spark_sql.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/operators/spark_sql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/operators/spark_submit.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/airflow/providers/apache/spark/operators/spark_submit.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/connections/spark.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/connections/spark.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/hooks/sqoop/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/hooks/sqoop/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/operators/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/operators/sqoop/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_api/airflow/providers/apache/sqoop/operators/sqoop/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_modules/airflow/providers/apache/sqoop/hooks/sqoop.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_modules/airflow/providers/apache/sqoop/hooks/sqoop.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_modules/airflow/providers/apache/sqoop/operators/sqoop.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_modules/airflow/providers/apache/sqoop/operators/sqoop.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/commits.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/genindex.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/search.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.1/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/hooks/asana/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/hooks/asana/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/operators/asana_tasks/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/operators/asana_tasks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/operators/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_api/airflow/providers/asana/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_modules/airflow/providers/asana/hooks/asana.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_modules/airflow/providers/asana/hooks/asana.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_modules/airflow/providers/asana/operators/asana_tasks.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_modules/airflow/providers/asana/operators/asana_tasks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/connections/asana.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/connections/asana.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/operators/asana.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/operators/asana.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/_api/airflow/providers/celery/index.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/_api/airflow/providers/celery/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/_api/airflow/providers/celery/sensors/celery_queue/index.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/_api/airflow/providers/celery/sensors/celery_queue/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/_api/airflow/providers/celery/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/_api/airflow/providers/celery/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/_modules/airflow/providers/celery/sensors/celery_queue.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/_modules/airflow/providers/celery/sensors/celery_queue.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-celery/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-celery/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/_api/airflow/providers/cloudant/hooks/cloudant/index.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/_api/airflow/providers/cloudant/hooks/cloudant/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/_api/airflow/providers/cloudant/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/_api/airflow/providers/cloudant/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/_api/airflow/providers/cloudant/index.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/_api/airflow/providers/cloudant/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/_modules/airflow/providers/cloudant/hooks/cloudant.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/_modules/airflow/providers/cloudant/hooks/cloudant.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/pod/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/pod/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/volume/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/volume/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/volume_mount/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/backcompat/volume_mount/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/hooks/kubernetes/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/hooks/kubernetes/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/operators/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/operators/kubernetes_pod/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/operators/kubernetes_pod/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/operators/spark_kubernetes/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/operators/spark_kubernetes/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/utils/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/utils/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/utils/pod_launcher/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/utils/pod_launcher/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/utils/xcom_sidecar/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_api/airflow/providers/cncf/kubernetes/utils/xcom_sidecar/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/pod.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/pod.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/volume.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/volume.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/volume_mount.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/backcompat/volume_mount.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/hooks/kubernetes.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/hooks/kubernetes.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/utils/pod_launcher.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/utils/pod_launcher.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/commits.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/connections/kubernetes.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/connections/kubernetes.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/genindex.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/operators.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/search.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/hooks/databricks/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/hooks/databricks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/operators/databricks/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/operators/databricks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/operators/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_api/airflow/providers/databricks/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/airflow/providers/databricks/example_dags/example_databricks.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/airflow/providers/databricks/example_dags/example_databricks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/airflow/providers/databricks/hooks/databricks.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/airflow/providers/databricks/hooks/databricks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/airflow/providers/databricks/operators/databricks.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/airflow/providers/databricks/operators/databricks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/connections/databricks.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/connections/databricks.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/hooks/datadog/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/hooks/datadog/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/sensors/datadog/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/sensors/datadog/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_api/airflow/providers/datadog/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_modules/airflow/providers/datadog/hooks/datadog.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_modules/airflow/providers/datadog/hooks/datadog.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_modules/airflow/providers/datadog/sensors/datadog.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_modules/airflow/providers/datadog/sensors/datadog.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-datadog/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/hooks/dingding/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/hooks/dingding/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/operators/dingding/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/operators/dingding/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/operators/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_api/airflow/providers/dingding/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/airflow/providers/dingding/example_dags/example_dingding.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/airflow/providers/dingding/example_dags/example_dingding.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/airflow/providers/dingding/hooks/dingding.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/airflow/providers/dingding/hooks/dingding.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/airflow/providers/dingding/operators/dingding.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/airflow/providers/dingding/operators/dingding.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/hooks/discord_webhook/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/hooks/discord_webhook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/operators/discord_webhook/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/operators/discord_webhook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/operators/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_api/airflow/providers/discord/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_modules/airflow/providers/discord/hooks/discord_webhook.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_modules/airflow/providers/discord/hooks/discord_webhook.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_modules/airflow/providers/discord/operators/discord_webhook.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_modules/airflow/providers/discord/operators/discord_webhook.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-discord/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/hooks/docker/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/hooks/docker/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/operators/docker/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/operators/docker/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/operators/docker_swarm/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/operators/docker_swarm/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/operators/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_api/airflow/providers/docker/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/airflow/providers/docker/hooks/docker.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/airflow/providers/docker/hooks/docker.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/airflow/providers/docker/operators/docker.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/airflow/providers/docker/operators/docker.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/airflow/providers/docker/operators/docker_swarm.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/airflow/providers/docker/operators/docker_swarm.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/connections/docker.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/connections/docker.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/hooks/elasticsearch/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/hooks/elasticsearch/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/log/es_task_handler/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/log/es_task_handler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/log/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_api/airflow/providers/elasticsearch/log/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_modules/airflow/providers/elasticsearch/hooks/elasticsearch.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_modules/airflow/providers/elasticsearch/hooks/elasticsearch.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_modules/airflow/providers/elasticsearch/log/es_task_handler.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_modules/airflow/providers/elasticsearch/log/es_task_handler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/commits.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/connections/elasticsearch.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/connections/elasticsearch.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/genindex.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/logging.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/logging.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/search.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.2/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/hooks/exasol/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/hooks/exasol/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/operators/exasol/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/operators/exasol/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/operators/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_api/airflow/providers/exasol/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_modules/airflow/providers/exasol/hooks/exasol.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_modules/airflow/providers/exasol/hooks/exasol.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_modules/airflow/providers/exasol/operators/exasol.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_modules/airflow/providers/exasol/operators/exasol.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-exasol/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/ads/hooks/ads/index.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/ads/hooks/ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/ads/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/ads/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/ads/index.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/index.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/_api/airflow/providers/facebook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/_modules/airflow/providers/facebook/ads/hooks/ads.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/_modules/airflow/providers/facebook/ads/hooks/ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-facebook/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/hooks/ftp/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/hooks/ftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/sensors/ftp/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/sensors/ftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_api/airflow/providers/ftp/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_modules/airflow/providers/ftp/hooks/ftp.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_modules/airflow/providers/ftp/hooks/ftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_modules/airflow/providers/ftp/sensors/ftp.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_modules/airflow/providers/ftp/sensors/ftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/connections/ftp.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/connections/ftp.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ftp/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/hooks/ads/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/hooks/ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/operators/ads/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/operators/ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/transfers/ads_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/transfers/ads_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/ads/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/automl/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/automl/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/bigquery/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/bigquery/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/bigquery_dts/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/bigquery_dts/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/bigtable/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/bigtable/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_build/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_build/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_memorystore/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_memorystore/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_sql/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_sql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/compute/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/compute/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/compute_ssh/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/compute_ssh/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/datacatalog/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/datacatalog/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dataflow/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dataflow/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/datafusion/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/datafusion/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dataprep/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dataprep/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dataproc/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dataproc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/datastore/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/datastore/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dlp/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/dlp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/functions/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/functions/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/gdm/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/gdm/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/kms/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/kms/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/kubernetes_engine/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/kubernetes_engine/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/life_sciences/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/life_sciences/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/mlengine/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/mlengine/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/natural_language/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/natural_language/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/os_login/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/os_login/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/pubsub/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/pubsub/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/secret_manager/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/secret_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/spanner/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/spanner/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/speech_to_text/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/speech_to_text/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/stackdriver/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/stackdriver/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/tasks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/tasks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/text_to_speech/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/text_to_speech/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/translate/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/translate/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/video_intelligence/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/video_intelligence/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/vision/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/vision/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/workflows/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/hooks/workflows/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/log/gcs_task_handler/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/log/gcs_task_handler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/log/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/log/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/log/stackdriver_task_handler/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/log/stackdriver_task_handler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/automl/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/automl/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/bigquery/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/bigquery/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/bigquery_dts/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/bigquery_dts/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/bigtable/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/bigtable/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_build/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_build/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_memorystore/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_memorystore/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_sql/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_sql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_storage_transfer_service/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/cloud_storage_transfer_service/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/compute/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/compute/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/datacatalog/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/datacatalog/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dataflow/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dataflow/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/datafusion/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/datafusion/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dataprep/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dataprep/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dataproc/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dataproc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/datastore/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/datastore/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dlp/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/dlp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/functions/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/functions/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/kubernetes_engine/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/kubernetes_engine/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/life_sciences/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/life_sciences/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/mlengine/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/mlengine/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/natural_language/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/natural_language/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/pubsub/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/pubsub/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/spanner/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/spanner/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/speech_to_text/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/speech_to_text/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/stackdriver/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/stackdriver/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/tasks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/tasks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/text_to_speech/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/text_to_speech/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/translate/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/translate/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/translate_speech/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/translate_speech/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/video_intelligence/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/video_intelligence/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/vision/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/vision/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/workflows/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/operators/workflows/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/secrets/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/secrets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/secrets/secret_manager/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/secrets/secret_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/bigquery/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/bigquery/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/bigquery_dts/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/bigquery_dts/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/bigtable/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/bigtable/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/dataflow/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/dataflow/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/dataproc/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/dataproc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/pubsub/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/pubsub/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/workflows/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/sensors/workflows/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/adls_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/adls_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_bigquery/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_bigquery/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_mssql/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_mssql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_mysql/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/bigquery_to_mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/cassandra_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/cassandra_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_bigquery/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_bigquery/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_local/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_local/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_sftp/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gcs_to_sftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gdrive_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gdrive_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gdrive_to_local/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/gdrive_to_local/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/local_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/local_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/mssql_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/mssql_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/mysql_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/mysql_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/oracle_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/oracle_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/postgres_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/postgres_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/presto_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/presto_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/s3_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/s3_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/salesforce_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/salesforce_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/sftp_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/sftp_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/sheets_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/sheets_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/sql_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/sql_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/trino_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/transfers/trino_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/credentials_provider/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/credentials_provider/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/field_sanitizer/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/field_sanitizer/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/field_validator/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/field_validator/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/mlengine_operator_utils/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/mlengine_operator_utils/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/mlengine_prediction_summary/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/cloud/utils/mlengine_prediction_summary/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/auth_backend/google_openid/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/auth_backend/google_openid/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/auth_backend/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/auth_backend/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/hooks/base_google/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/hooks/base_google/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/hooks/discovery_api/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/hooks/discovery_api/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/utils/id_token_credentials/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/utils/id_token_credentials/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/utils/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/common/utils/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/hooks/firestore/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/hooks/firestore/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/operators/firestore/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/operators/firestore/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/firebase/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/hooks/leveldb/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/hooks/leveldb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/operators/leveldb/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/leveldb/operators/leveldb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/analytics/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/analytics/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/campaign_manager/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/campaign_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/display_video/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/display_video/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/search_ads/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/hooks/search_ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/analytics/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/analytics/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/campaign_manager/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/campaign_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/display_video/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/display_video/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/search_ads/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/operators/search_ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/campaign_manager/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/campaign_manager/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/display_video/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/display_video/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/search_ads/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/marketing_platform/sensors/search_ads/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/hooks/drive/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/hooks/drive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/hooks/sheets/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/hooks/sheets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/operators/sheets/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/operators/sheets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/sensors/drive/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/sensors/drive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/transfers/gcs_to_gdrive/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/transfers/gcs_to_gdrive/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/transfers/gcs_to_sheets/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/transfers/gcs_to_sheets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_api/airflow/providers/google/suite/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/example_dags/example_ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/example_dags/example_ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/hooks/ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/hooks/ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/operators/ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/operators/ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/transfers/ads_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/ads/transfers/ads_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_automl_tables.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_automl_tables.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigquery_operations.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigquery_operations.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigquery_queries.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigquery_queries.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigquery_sensors.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigquery_sensors.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigtable.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_bigtable.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_build.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_build.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_memorystore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_memorystore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_sql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_sql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_sql_query.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_sql_query.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_gcp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_gcp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_compute.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_compute.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_compute_igm.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_compute_igm.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_compute_ssh.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_compute_ssh.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_datacatalog.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_datacatalog.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataflow.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataflow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataflow_flex_template.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataflow_flex_template.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataflow_sql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataflow_sql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_datafusion.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_datafusion.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataprep.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataprep.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataproc.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dataproc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_datastore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_datastore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dlp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_dlp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_facebook_ads_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_facebook_ads_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_functions.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_functions.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_timespan_file_transform.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_timespan_file_transform.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_bigquery.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_local.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_local.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_sftp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gcs_to_sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gdrive_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gdrive_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gdrive_to_local.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_gdrive_to_local.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_kubernetes_engine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_kubernetes_engine.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_life_sciences.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_life_sciences.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_local_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_local_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_mlengine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_mlengine.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_mysql_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_mysql_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_natural_language.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_natural_language.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_oracle_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_oracle_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_presto_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_presto_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_pubsub.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_pubsub.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_salesforce_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_salesforce_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_sftp_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_sftp_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_sheets_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_sheets_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_spanner.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_spanner.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_speech_to_text.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_speech_to_text.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_stackdriver.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_stackdriver.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_text_to_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_text_to_speech.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_translate.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_translate.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_translate_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_translate_speech.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_trino_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_trino_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_video_intelligence.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_video_intelligence.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_vision.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_vision.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_workflows.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/example_dags/example_workflows.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/automl.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/automl.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/bigquery.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/bigquery_dts.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/bigquery_dts.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/bigtable.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/bigtable.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_build.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_build.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_memorystore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_memorystore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_sql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_sql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/compute.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/compute.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/compute_ssh.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/compute_ssh.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/datacatalog.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/datacatalog.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dataflow.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dataflow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/datafusion.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/datafusion.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dataprep.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dataprep.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dataproc.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dataproc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/datastore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/datastore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dlp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/dlp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/functions.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/functions.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/gdm.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/gdm.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/kms.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/kms.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/kubernetes_engine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/kubernetes_engine.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/life_sciences.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/life_sciences.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/mlengine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/mlengine.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/natural_language.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/natural_language.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/os_login.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/os_login.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/pubsub.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/pubsub.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/secret_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/secret_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/spanner.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/spanner.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/speech_to_text.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/speech_to_text.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/stackdriver.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/stackdriver.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/tasks.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/tasks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/text_to_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/text_to_speech.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/translate.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/translate.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/video_intelligence.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/video_intelligence.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/vision.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/vision.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/workflows.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/hooks/workflows.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/log/gcs_task_handler.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/log/gcs_task_handler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/log/stackdriver_task_handler.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/log/stackdriver_task_handler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/automl.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/automl.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/bigquery.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/bigquery_dts.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/bigquery_dts.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/bigtable.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/bigtable.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_build.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_build.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_memorystore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_memorystore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_sql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_sql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/compute.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/compute.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/datacatalog.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/datacatalog.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dataflow.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dataflow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/datafusion.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/datafusion.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dataprep.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dataprep.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dataproc.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dataproc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/datastore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/datastore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dlp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/dlp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/functions.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/functions.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/kubernetes_engine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/kubernetes_engine.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/life_sciences.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/life_sciences.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/mlengine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/mlengine.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/natural_language.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/natural_language.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/pubsub.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/pubsub.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/spanner.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/spanner.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/speech_to_text.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/speech_to_text.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/stackdriver.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/stackdriver.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/tasks.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/tasks.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/text_to_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/text_to_speech.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/translate.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/translate.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/translate_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/translate_speech.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/video_intelligence.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/video_intelligence.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/vision.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/vision.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/workflows.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/operators/workflows.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/secrets/secret_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/secrets/secret_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/bigquery.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/bigquery_dts.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/bigquery_dts.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/bigtable.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/bigtable.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/dataflow.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/dataflow.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/dataproc.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/dataproc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/pubsub.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/pubsub.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/workflows.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/sensors/workflows.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/adls_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/adls_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_mssql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_mssql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_mysql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/bigquery_to_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/cassandra_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/cassandra_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_bigquery.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_local.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_local.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_sftp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gcs_to_sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gdrive_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gdrive_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gdrive_to_local.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/gdrive_to_local.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/local_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/local_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/mssql_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/mssql_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/mysql_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/mysql_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/oracle_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/oracle_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/postgres_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/postgres_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/presto_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/presto_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/s3_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/s3_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/salesforce_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/salesforce_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/sftp_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/sftp_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/sheets_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/sheets_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/sql_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/sql_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/trino_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/transfers/trino_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/credentials_provider.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/credentials_provider.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/field_sanitizer.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/field_sanitizer.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/field_validator.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/field_validator.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/mlengine_operator_utils.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/mlengine_operator_utils.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/mlengine_prediction_summary.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/cloud/utils/mlengine_prediction_summary.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/auth_backend/google_openid.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/auth_backend/google_openid.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/hooks/base_google.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/hooks/base_google.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/hooks/discovery_api.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/hooks/discovery_api.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/utils/id_token_credentials.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/common/utils/id_token_credentials.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/firebase/example_dags/example_firestore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/firebase/example_dags/example_firestore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/firebase/hooks/firestore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/firebase/hooks/firestore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/firebase/operators/firestore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/firebase/operators/firestore.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/leveldb/example_dags/example_leveldb.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/leveldb/example_dags/example_leveldb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/leveldb/hooks/leveldb.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/leveldb/hooks/leveldb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/leveldb/operators/leveldb.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/leveldb/operators/leveldb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_analytics.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_analytics.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_display_video.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_display_video.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_search_ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/example_dags/example_search_ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/analytics.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/analytics.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/campaign_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/campaign_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/display_video.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/display_video.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/search_ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/hooks/search_ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/analytics.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/analytics.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/campaign_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/campaign_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/display_video.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/display_video.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/search_ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/operators/search_ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/sensors/campaign_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/sensors/campaign_manager.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/sensors/display_video.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/sensors/display_video.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/sensors/search_ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/marketing_platform/sensors/search_ads.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/example_dags/example_gcs_to_gdrive.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/example_dags/example_gcs_to_gdrive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/example_dags/example_gcs_to_sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/example_dags/example_gcs_to_sheets.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/example_dags/example_sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/example_dags/example_sheets.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/hooks/drive.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/hooks/drive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/hooks/sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/hooks/sheets.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/operators/sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/operators/sheets.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/sensors/drive.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/sensors/drive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/transfers/gcs_to_gdrive.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/transfers/gcs_to_gdrive.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/transfers/gcs_to_sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/airflow/providers/google/suite/transfers/gcs_to_sheets.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/api-auth-backend/google-openid.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/api-auth-backend/google-openid.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/configurations-ref.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/configurations-ref.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/connections/gcp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/connections/gcp.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/connections/gcp_sql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/connections/gcp_sql.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/connections/gcp_ssh.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/connections/gcp_ssh.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/connections/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/connections/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/example-dags.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/logging/gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/logging/gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/logging/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/logging/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/logging/stackdriver.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/logging/stackdriver.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/ads.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/automl.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/automl.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/bigquery.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/bigquery.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/bigquery_dts.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/bigquery_dts.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/bigtable.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/bigtable.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_build.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_build.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_memorystore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_memorystore.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_memorystore_memcached.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_memorystore_memcached.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_sql.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_sql.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_storage_transfer_service.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/cloud_storage_transfer_service.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/compute.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/compute.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/compute_ssh.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/compute_ssh.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/data_loss_prevention.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/data_loss_prevention.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/datacatalog.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/datacatalog.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/dataflow.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/dataflow.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/datafusion.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/datafusion.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/dataprep.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/dataprep.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/dataproc.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/dataproc.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/datastore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/datastore.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/functions.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/functions.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/kubernetes_engine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/kubernetes_engine.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/life_sciences.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/life_sciences.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/mlengine.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/mlengine.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/natural_language.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/natural_language.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/pubsub.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/pubsub.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/spanner.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/spanner.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/speech_to_text.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/speech_to_text.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/stackdriver.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/stackdriver.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/text_to_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/text_to_speech.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/translate.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/translate.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/translate_speech.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/translate_speech.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/video_intelligence.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/video_intelligence.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/vision.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/vision.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/workflows.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/cloud/workflows.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/firebase/firestore.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/firebase/firestore.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/leveldb/leveldb.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/leveldb/leveldb.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/analytics.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/analytics.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/campaign_manager.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/campaign_manager.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/display_video.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/display_video.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/search_ads.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/marketing_platform/search_ads.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/suite/sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/suite/sheets.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/azure_fileshare_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/azure_fileshare_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/facebook_ads_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/facebook_ads_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_gdrive.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_gdrive.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_local.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_local.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_sftp.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_sftp.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_sheets.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gcs_to_sheets.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gdrive_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gdrive_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gdrive_to_local.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/gdrive_to_local.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/index.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/local_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/local_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/mysql_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/mysql_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/oracle_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/oracle_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/presto_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/presto_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/s3_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/s3_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/salesforce_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/salesforce_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/sftp_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/sftp_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/sheets_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/sheets_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/trino_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/operators/transfer/trino_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-google/5.0.0/secrets-backends/google-cloud-secret-manager-backend.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/secrets-backends/google-cloud-secret-manager-backend.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/hooks/grpc/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/hooks/grpc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/operators/grpc/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/operators/grpc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/operators/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_api/airflow/providers/grpc/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_modules/airflow/providers/grpc/hooks/grpc.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_modules/airflow/providers/grpc/hooks/grpc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_modules/airflow/providers/grpc/operators/grpc.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_modules/airflow/providers/grpc/operators/grpc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/connections/grpc.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/connections/grpc.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-grpc/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/hooks/vault/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/hooks/vault/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/secrets/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/secrets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/secrets/vault/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_api/airflow/providers/hashicorp/secrets/vault/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_modules/airflow/providers/hashicorp/hooks/vault.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_modules/airflow/providers/hashicorp/hooks/vault.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_modules/airflow/providers/hashicorp/secrets/vault.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_modules/airflow/providers/hashicorp/secrets/vault.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-hashicorp/2.0.0/secrets-backends/hashicorp-vault.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.0.0/secrets-backends/hashicorp-vault.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/hooks/http/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/hooks/http/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/operators/http/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/operators/http/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/operators/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/sensors/http/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/sensors/http/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_api/airflow/providers/http/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/example_dags/example_http.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/example_dags/example_http.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/hooks/http.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/hooks/http.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/operators/http.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/operators/http.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/sensors/http.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_modules/airflow/providers/http/sensors/http.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/connections/http.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/connections/http.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-http/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/hooks/imap/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/hooks/imap/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/sensors/imap_attachment/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/sensors/imap_attachment/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_api/airflow/providers/imap/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_modules/airflow/providers/imap/hooks/imap.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_modules/airflow/providers/imap/hooks/imap.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_modules/airflow/providers/imap/sensors/imap_attachment.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_modules/airflow/providers/imap/sensors/imap_attachment.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/connections/imap.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/connections/imap.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-imap/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/hooks/jdbc/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/hooks/jdbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/operators/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/operators/jdbc/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_api/airflow/providers/jdbc/operators/jdbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/airflow/providers/jdbc/example_dags/example_jdbc_queries.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/airflow/providers/jdbc/example_dags/example_jdbc_queries.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/airflow/providers/jdbc/hooks/jdbc.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/airflow/providers/jdbc/hooks/jdbc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/airflow/providers/jdbc/operators/jdbc.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/airflow/providers/jdbc/operators/jdbc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/connections/jdbc.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/connections/jdbc.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/hooks/jenkins/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/hooks/jenkins/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/operators/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/operators/jenkins_job_trigger/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_api/airflow/providers/jenkins/operators/jenkins_job_trigger/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_modules/airflow/providers/jenkins/hooks/jenkins.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_modules/airflow/providers/jenkins/hooks/jenkins.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_modules/airflow/providers/jenkins/operators/jenkins_job_trigger.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_modules/airflow/providers/jenkins/operators/jenkins_job_trigger.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/commits.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/genindex.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/search.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/hooks/jira/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/hooks/jira/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/operators/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/operators/jira/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/operators/jira/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/sensors/jira/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_api/airflow/providers/jira/sensors/jira/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/airflow/providers/jira/hooks/jira.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/airflow/providers/jira/hooks/jira.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/airflow/providers/jira/operators/jira.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/airflow/providers/jira/operators/jira.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/airflow/providers/jira/sensors/jira.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/airflow/providers/jira/sensors/jira.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-jira/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/adx/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/adx/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_batch/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_batch/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_container_instance/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_container_instance/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_container_registry/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_container_registry/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_container_volume/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_container_volume/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_cosmos/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_cosmos/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_data_factory/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_data_factory/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_data_lake/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_data_lake/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_fileshare/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/azure_fileshare/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/base_azure/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/base_azure/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/wasb/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/hooks/wasb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/log/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/log/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/log/wasb_task_handler/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/log/wasb_task_handler/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/adls_delete/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/adls_delete/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/adls_list/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/adls_list/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/adx/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/adx/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/azure_batch/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/azure_batch/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/azure_container_instances/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/azure_container_instances/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/azure_cosmos/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/azure_cosmos/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/wasb_delete_blob/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/operators/wasb_delete_blob/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/secrets/azure_key_vault/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/secrets/azure_key_vault/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/secrets/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/secrets/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/sensors/azure_cosmos/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/sensors/azure_cosmos/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/sensors/wasb/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/sensors/wasb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/file_to_wasb/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/file_to_wasb/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/local_to_adls/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/local_to_adls/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_api/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/example_dags/example_adls_delete.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/example_dags/example_adls_delete.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/example_dags/example_azure_blob_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/example_dags/example_azure_blob_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/adx.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/adx.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_batch.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_batch.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_container_instance.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_container_instance.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_container_registry.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_container_registry.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_container_volume.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_container_volume.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_cosmos.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_cosmos.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_data_factory.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_data_factory.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_data_lake.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_data_lake.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_fileshare.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/azure_fileshare.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/base_azure.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/base_azure.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/wasb.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/hooks/wasb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/log/wasb_task_handler.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/log/wasb_task_handler.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/adls_delete.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/adls_delete.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/adls_list.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/adls_list.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/adx.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/adx.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/azure_batch.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/azure_batch.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/azure_container_instances.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/azure_container_instances.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/azure_cosmos.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/azure_cosmos.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/wasb_delete_blob.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/operators/wasb_delete_blob.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/secrets/azure_key_vault.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/secrets/azure_key_vault.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/sensors/azure_cosmos.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/sensors/azure_cosmos.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/sensors/wasb.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/sensors/wasb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/azure_blob_to_gcs.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/file_to_wasb.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/file_to_wasb.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/local_to_adls.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/local_to_adls.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/acr.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/acr.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/adf.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/adf.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/adl.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/adl.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/adx.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/adx.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_batch.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_batch.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_container_volume.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_container_volume.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_cosmos.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_cosmos.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_fileshare.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/azure_fileshare.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/wasb.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/connections/wasb.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/logging.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/logging.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/adls.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/adls.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/azure_blob_to_gcs.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/azure_blob_to_gcs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/local_to_adls.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/operators/local_to_adls.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/secrets-backends/azure-key-vault.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/secrets-backends/azure-key-vault.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/hooks/mssql/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/hooks/mssql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/operators/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/operators/mssql/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_api/airflow/providers/microsoft/mssql/operators/mssql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_modules/airflow/providers/microsoft/mssql/hooks/mssql.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_modules/airflow/providers/microsoft/mssql/hooks/mssql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_modules/airflow/providers/microsoft/mssql/operators/mssql.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_modules/airflow/providers/microsoft/mssql/operators/mssql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/hooks/winrm/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/hooks/winrm/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/operators/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/operators/winrm/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_api/airflow/providers/microsoft/winrm/operators/winrm/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_modules/airflow/providers/microsoft/winrm/hooks/winrm.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_modules/airflow/providers/microsoft/winrm/hooks/winrm.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_modules/airflow/providers/microsoft/winrm/operators/winrm.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_modules/airflow/providers/microsoft/winrm/operators/winrm.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/hooks/mongo/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/hooks/mongo/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/sensors/mongo/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_api/airflow/providers/mongo/sensors/mongo/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_modules/airflow/providers/mongo/hooks/mongo.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_modules/airflow/providers/mongo/hooks/mongo.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_modules/airflow/providers/mongo/sensors/mongo.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_modules/airflow/providers/mongo/sensors/mongo.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/connections/mongo.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/connections/mongo.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mongo/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/hooks/mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/hooks/mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/operators/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/operators/mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/operators/mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/presto_to_mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/presto_to_mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/s3_to_mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/s3_to_mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/trino_to_mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/trino_to_mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/vertica_to_mysql/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_api/airflow/providers/mysql/transfers/vertica_to_mysql/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/example_dags/example_mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/example_dags/example_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/hooks/mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/hooks/mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/operators/mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/operators/mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/presto_to_mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/presto_to_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/s3_to_mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/s3_to_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/trino_to_mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/trino_to_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/vertica_to_mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/airflow/providers/mysql/transfers/vertica_to_mysql.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/connections/mysql.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/connections/mysql.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/operators.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/hooks/neo4j/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/hooks/neo4j/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/operators/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/operators/neo4j/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_api/airflow/providers/neo4j/operators/neo4j/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_modules/airflow/providers/neo4j/hooks/neo4j.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_modules/airflow/providers/neo4j/hooks/neo4j.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_modules/airflow/providers/neo4j/operators/neo4j.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_modules/airflow/providers/neo4j/operators/neo4j.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/connections/neo4j.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/connections/neo4j.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/operators/neo4j.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/operators/neo4j.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/_api/airflow/providers/odbc/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/_api/airflow/providers/odbc/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/_api/airflow/providers/odbc/hooks/odbc/index.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/_api/airflow/providers/odbc/hooks/odbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/_api/airflow/providers/odbc/index.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/_api/airflow/providers/odbc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/_modules/airflow/providers/odbc/hooks/odbc.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/_modules/airflow/providers/odbc/hooks/odbc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/connections/odbc.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/connections/odbc.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-odbc/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/_api/airflow/providers/openfaas/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/_api/airflow/providers/openfaas/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/_api/airflow/providers/openfaas/hooks/openfaas/index.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/_api/airflow/providers/openfaas/hooks/openfaas/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/_api/airflow/providers/openfaas/index.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/_api/airflow/providers/openfaas/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/_modules/airflow/providers/openfaas/hooks/openfaas.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/_modules/airflow/providers/openfaas/hooks/openfaas.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/hooks/opsgenie_alert/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/hooks/opsgenie_alert/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/operators/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/operators/opsgenie_alert/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_api/airflow/providers/opsgenie/operators/opsgenie_alert/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_modules/airflow/providers/opsgenie/hooks/opsgenie_alert.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_modules/airflow/providers/opsgenie/hooks/opsgenie_alert.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_modules/airflow/providers/opsgenie/operators/opsgenie_alert.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_modules/airflow/providers/opsgenie/operators/opsgenie_alert.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/hooks/oracle/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/hooks/oracle/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/operators/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/operators/oracle/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/operators/oracle/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/transfers/oracle_to_oracle/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_api/airflow/providers/oracle/transfers/oracle_to_oracle/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/airflow/providers/oracle/hooks/oracle.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/airflow/providers/oracle/hooks/oracle.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/airflow/providers/oracle/operators/oracle.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/airflow/providers/oracle/operators/oracle.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/airflow/providers/oracle/transfers/oracle_to_oracle.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/airflow/providers/oracle/transfers/oracle_to_oracle.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/connections/oracle.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/connections/oracle.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-oracle/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_api/airflow/providers/pagerduty/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_api/airflow/providers/pagerduty/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_api/airflow/providers/pagerduty/hooks/pagerduty/index.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_api/airflow/providers/pagerduty/hooks/pagerduty/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_api/airflow/providers/pagerduty/index.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_api/airflow/providers/pagerduty/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_modules/airflow/providers/pagerduty/hooks/pagerduty.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_modules/airflow/providers/pagerduty/hooks/pagerduty.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/_api/airflow/providers/papermill/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/_api/airflow/providers/papermill/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/_api/airflow/providers/papermill/operators/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/_api/airflow/providers/papermill/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/_api/airflow/providers/papermill/operators/papermill/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/_api/airflow/providers/papermill/operators/papermill/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/_modules/airflow/providers/papermill/example_dags/example_papermill.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/_modules/airflow/providers/papermill/example_dags/example_papermill.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/_modules/airflow/providers/papermill/operators/papermill.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/_modules/airflow/providers/papermill/operators/papermill.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/hooks/plexus/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/hooks/plexus/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/operators/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/operators/job/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_api/airflow/providers/plexus/operators/job/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_modules/airflow/providers/plexus/hooks/plexus.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_modules/airflow/providers/plexus/hooks/plexus.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_modules/airflow/providers/plexus/operators/job.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_modules/airflow/providers/plexus/operators/job.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/hooks/postgres/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/hooks/postgres/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/operators/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/operators/postgres/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_api/airflow/providers/postgres/operators/postgres/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/airflow/providers/postgres/example_dags/example_postgres.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/airflow/providers/postgres/example_dags/example_postgres.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/airflow/providers/postgres/hooks/postgres.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/airflow/providers/postgres/hooks/postgres.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/airflow/providers/postgres/operators/postgres.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/airflow/providers/postgres/operators/postgres.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/connections/postgres.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/connections/postgres.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/operators/postgres_operator_howto_guide.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/operators/postgres_operator_howto_guide.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/_api/airflow/providers/presto/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/_api/airflow/providers/presto/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/_api/airflow/providers/presto/hooks/presto/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/_api/airflow/providers/presto/hooks/presto/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/_api/airflow/providers/presto/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/_api/airflow/providers/presto/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/_modules/airflow/providers/presto/hooks/presto.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/_modules/airflow/providers/presto/hooks/presto.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-presto/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/hooks/qubole/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/hooks/qubole/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/hooks/qubole_check/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/hooks/qubole_check/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/operators/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/operators/qubole/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/operators/qubole/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/operators/qubole_check/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/operators/qubole_check/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/sensors/qubole/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_api/airflow/providers/qubole/sensors/qubole/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/hooks/qubole.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/hooks/qubole.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/hooks/qubole_check.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/hooks/qubole_check.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/operators/qubole.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/operators/qubole.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/operators/qubole_check.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/operators/qubole_check.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/sensors/qubole.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/airflow/providers/qubole/sensors/qubole.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/hooks/redis/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/hooks/redis/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/operators/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/operators/redis_publish/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/operators/redis_publish/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/sensors/redis_key/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/sensors/redis_key/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/sensors/redis_pub_sub/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_api/airflow/providers/redis/sensors/redis_pub_sub/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/hooks/redis.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/hooks/redis.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/operators/redis_publish.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/operators/redis_publish.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/sensors/redis_key.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/sensors/redis_key.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/sensors/redis_pub_sub.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/airflow/providers/redis/sensors/redis_pub_sub.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-redis/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/hooks/salesforce/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/hooks/salesforce/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/hooks/tableau/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/hooks/tableau/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/operators/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/operators/tableau_refresh_workbook/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/operators/tableau_refresh_workbook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/sensors/tableau_job_status/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_api/airflow/providers/salesforce/sensors/tableau_job_status/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_modules/airflow/providers/salesforce/hooks/salesforce.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_modules/airflow/providers/salesforce/hooks/salesforce.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/connections/salesforce.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/connections/salesforce.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/hooks/salesforce/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/hooks/salesforce/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/hooks/tableau/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/hooks/tableau/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/operators/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/operators/tableau_refresh_workbook/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/operators/tableau_refresh_workbook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/sensors/tableau_job_status/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_api/airflow/providers/salesforce/sensors/tableau_job_status/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_modules/airflow/providers/salesforce/hooks/salesforce.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_modules/airflow/providers/salesforce/hooks/salesforce.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/connections/salesforce.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/connections/salesforce.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/_api/airflow/providers/samba/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/_api/airflow/providers/samba/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/_api/airflow/providers/samba/hooks/samba/index.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/_api/airflow/providers/samba/hooks/samba/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/_api/airflow/providers/samba/index.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/_api/airflow/providers/samba/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/_modules/airflow/providers/samba/hooks/samba.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/_modules/airflow/providers/samba/hooks/samba.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-samba/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-samba/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/hooks/segment/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/hooks/segment/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/operators/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/operators/segment_track_event/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_api/airflow/providers/segment/operators/segment_track_event/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_modules/airflow/providers/segment/hooks/segment.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_modules/airflow/providers/segment/hooks/segment.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_modules/airflow/providers/segment/operators/segment_track_event.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_modules/airflow/providers/segment/operators/segment_track_event.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-segment/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_api/airflow/providers/sendgrid/index.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_api/airflow/providers/sendgrid/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_api/airflow/providers/sendgrid/utils/emailer/index.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_api/airflow/providers/sendgrid/utils/emailer/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_api/airflow/providers/sendgrid/utils/index.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_api/airflow/providers/sendgrid/utils/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_modules/airflow/providers/sendgrid/utils/emailer.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_modules/airflow/providers/sendgrid/utils/emailer.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/hooks/sftp/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/hooks/sftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/operators/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/operators/sftp/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/operators/sftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/sensors/sftp/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_api/airflow/providers/sftp/sensors/sftp/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/airflow/providers/sftp/hooks/sftp.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/airflow/providers/sftp/hooks/sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/airflow/providers/sftp/operators/sftp.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/airflow/providers/sftp/operators/sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/airflow/providers/sftp/sensors/sftp.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/airflow/providers/sftp/sensors/sftp.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/connections/sftp.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/connections/sftp.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sftp/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/_api/airflow/providers/singularity/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/_api/airflow/providers/singularity/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/_api/airflow/providers/singularity/operators/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/_api/airflow/providers/singularity/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/_api/airflow/providers/singularity/operators/singularity/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/_api/airflow/providers/singularity/operators/singularity/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/_modules/airflow/providers/singularity/operators/singularity.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/_modules/airflow/providers/singularity/operators/singularity.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/hooks/slack/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/hooks/slack/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/hooks/slack_webhook/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/hooks/slack_webhook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/operators/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/operators/slack/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/operators/slack/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/operators/slack_webhook/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_api/airflow/providers/slack/operators/slack_webhook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/hooks/slack.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/hooks/slack.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/hooks/slack_webhook.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/hooks/slack_webhook.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/operators/slack.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/operators/slack.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/operators/slack_webhook.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/airflow/providers/slack/operators/slack_webhook.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/connections/slack.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/connections/slack.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-slack/4.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/hooks/snowflake/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/hooks/snowflake/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/operators/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/operators/snowflake/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/operators/snowflake/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/transfers/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/transfers/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/transfers/s3_to_snowflake/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/transfers/s3_to_snowflake/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/transfers/snowflake_to_slack/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_api/airflow/providers/snowflake/transfers/snowflake_to_slack/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/example_dags/example_snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/example_dags/example_snowflake.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/hooks/snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/hooks/snowflake.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/operators/snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/operators/snowflake.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/transfers/s3_to_snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/transfers/s3_to_snowflake.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/transfers/snowflake_to_slack.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/airflow/providers/snowflake/transfers/snowflake_to_slack.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/connections/snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/connections/snowflake.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/s3_to_snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/s3_to_snowflake.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/snowflake.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/snowflake.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/snowflake_to_slack.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/operators/snowflake_to_slack.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/hooks/sqlite/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/hooks/sqlite/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/operators/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/operators/sqlite/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_api/airflow/providers/sqlite/operators/sqlite/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/airflow/providers/sqlite/example_dags/example_sqlite.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/airflow/providers/sqlite/example_dags/example_sqlite.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/airflow/providers/sqlite/hooks/sqlite.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/airflow/providers/sqlite/hooks/sqlite.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/airflow/providers/sqlite/operators/sqlite.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/airflow/providers/sqlite/operators/sqlite.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/connections/sqlite.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/connections/sqlite.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/hooks/ssh/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/hooks/ssh/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/operators/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/operators/ssh/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_api/airflow/providers/ssh/operators/ssh/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_modules/airflow/providers/ssh/hooks/ssh.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_modules/airflow/providers/ssh/hooks/ssh.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_modules/airflow/providers/ssh/operators/ssh.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_modules/airflow/providers/ssh/operators/ssh.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/connections/ssh.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/connections/ssh.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-ssh/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/hooks/tableau/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/hooks/tableau/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/operators/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/operators/tableau_refresh_workbook/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/operators/tableau_refresh_workbook/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/sensors/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/sensors/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/sensors/tableau_job_status/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_api/airflow/providers/tableau/sensors/tableau_job_status/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/airflow/providers/tableau/hooks/tableau.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/airflow/providers/tableau/hooks/tableau.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/airflow/providers/tableau/operators/tableau_refresh_workbook.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/airflow/providers/tableau/operators/tableau_refresh_workbook.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/airflow/providers/tableau/sensors/tableau_job_status.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/airflow/providers/tableau/sensors/tableau_job_status.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/commits.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/connections/tableau.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/connections/tableau.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/search.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/hooks/telegram/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/hooks/telegram/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/operators/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/operators/telegram/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_api/airflow/providers/telegram/operators/telegram/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/airflow/providers/telegram/example_dags/example_telegram.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/airflow/providers/telegram/example_dags/example_telegram.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/airflow/providers/telegram/hooks/telegram.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/airflow/providers/telegram/hooks/telegram.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/airflow/providers/telegram/operators/telegram.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/airflow/providers/telegram/operators/telegram.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/_api/airflow/providers/trino/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/_api/airflow/providers/trino/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/_api/airflow/providers/trino/hooks/trino/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/_api/airflow/providers/trino/hooks/trino/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/_api/airflow/providers/trino/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/_api/airflow/providers/trino/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/_modules/airflow/providers/trino/hooks/trino.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/_modules/airflow/providers/trino/hooks/trino.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-trino/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/hooks/vertica/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/hooks/vertica/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/operators/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/operators/vertica/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_api/airflow/providers/vertica/operators/vertica/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_modules/airflow/providers/vertica/hooks/vertica.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_modules/airflow/providers/vertica/hooks/vertica.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_modules/airflow/providers/vertica/operators/vertica.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_modules/airflow/providers/vertica/operators/vertica.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-vertica/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/hooks/yandex/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/hooks/yandex/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/hooks/yandexcloud_dataproc/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/hooks/yandexcloud_dataproc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/operators/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/operators/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/operators/yandexcloud_dataproc/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_api/airflow/providers/yandex/operators/yandexcloud_dataproc/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/airflow/providers/yandex/hooks/yandex.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/airflow/providers/yandex/hooks/yandex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/airflow/providers/yandex/hooks/yandexcloud_dataproc.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/airflow/providers/yandex/hooks/yandexcloud_dataproc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/airflow/providers/yandex/operators/yandexcloud_dataproc.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/airflow/providers/yandex/operators/yandexcloud_dataproc.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/connections/yandexcloud.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/connections/yandexcloud.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/operators.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/operators.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/_api/airflow/providers/zendesk/hooks/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/_api/airflow/providers/zendesk/hooks/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/_api/airflow/providers/zendesk/hooks/zendesk/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/_api/airflow/providers/zendesk/hooks/zendesk/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/_api/airflow/providers/zendesk/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/_api/airflow/providers/zendesk/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/_modules/airflow/providers/zendesk/hooks/zendesk.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/_modules/airflow/providers/zendesk/hooks/zendesk.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/_modules/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/commits.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/commits.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/genindex.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/py-modindex.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/py-modindex.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.0/search.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/_modules/index.html
+++ b/docs-archive/apache-airflow-providers/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/genindex.html
+++ b/docs-archive/apache-airflow-providers/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/howto/create-update-providers.html
+++ b/docs-archive/apache-airflow-providers/howto/create-update-providers.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/index.html
+++ b/docs-archive/apache-airflow-providers/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/apache.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/apache.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/aws.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/aws.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/azure.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/azure.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/google.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/google.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/index.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/protocol.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/protocol.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/services.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/services.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/operators-and-hooks-ref/software.html
+++ b/docs-archive/apache-airflow-providers/operators-and-hooks-ref/software.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/packages-ref.html
+++ b/docs-archive/apache-airflow-providers/packages-ref.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow-providers/search.html
+++ b/docs-archive/apache-airflow-providers/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/exceptions/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/exceptions/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/base_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/base_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/celery_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/celery_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/celery_kubernetes_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/celery_kubernetes_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/dask_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/dask_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/debug_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/debug_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/executor_constants/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/executor_constants/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/executor_loader/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/executor_loader/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/kubernetes_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/kubernetes_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/local_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/local_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/sequential_executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/executors/sequential_executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/S3_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/S3_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/base/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/base/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/base_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/base_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/dbapi/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/dbapi/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/dbapi_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/dbapi_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/docker_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/docker_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/druid_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/druid_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/filesystem/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/filesystem/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/hdfs_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/hdfs_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/hive_hooks/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/hive_hooks/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/http_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/http_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/jdbc_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/jdbc_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/mssql_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/mssql_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/mysql_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/mysql_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/oracle_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/oracle_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/pig_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/pig_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/postgres_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/postgres_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/presto_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/presto_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/samba_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/samba_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/slack_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/slack_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/sqlite_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/sqlite_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/subprocess/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/subprocess/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/webhdfs_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/webhdfs_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/zendesk_hook/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/hooks/zendesk_hook/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/base/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/base/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/baseoperator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/baseoperator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/connection/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/connection/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/crypto/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/crypto/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dag/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dag/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagbag/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagbag/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagcode/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagcode/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagparam/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagparam/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagpickle/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagpickle/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagrun/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/dagrun/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/errors/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/errors/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/log/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/log/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/pool/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/pool/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/renderedtifields/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/renderedtifields/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/sensorinstance/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/sensorinstance/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/serialized_dag/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/serialized_dag/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/skipmixin/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/skipmixin/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/slamiss/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/slamiss/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskfail/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskfail/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskinstance/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskinstance/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskmixin/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskmixin/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskreschedule/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/taskreschedule/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/variable/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/variable/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/xcom/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/xcom/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/models/xcom_arg/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/models/xcom_arg/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/bash/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/bash/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/bash_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/bash_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/branch/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/branch/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/branch_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/branch_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/check_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/check_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/dagrun_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/dagrun_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/datetime/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/datetime/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/docker_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/docker_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/druid_check_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/druid_check_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/dummy/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/dummy/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/dummy_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/dummy_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/email/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/email/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/email_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/email_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/gcs_to_s3/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/gcs_to_s3/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/generic_transfer/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/generic_transfer/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/google_api_to_s3_transfer/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/google_api_to_s3_transfer/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_stats_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_stats_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_to_druid/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_to_druid/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_to_mysql/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_to_mysql/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_to_samba_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/hive_to_samba_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/http_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/http_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/jdbc_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/jdbc_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/latest_only/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/latest_only/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/latest_only_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/latest_only_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mssql_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mssql_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mssql_to_hive/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mssql_to_hive/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mysql_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mysql_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mysql_to_hive/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/mysql_to_hive/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/oracle_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/oracle_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/papermill_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/papermill_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/pig_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/pig_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/postgres_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/postgres_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/presto_check_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/presto_check_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/presto_to_mysql/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/presto_to_mysql/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/python/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/python/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/python_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/python_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/redshift_to_s3_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/redshift_to_s3_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/s3_file_transform_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/s3_file_transform_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/s3_to_hive_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/s3_to_hive_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/s3_to_redshift_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/s3_to_redshift_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/slack_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/slack_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/sql/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/sql/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/sql_branch_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/sql_branch_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/sqlite_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/sqlite_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/subdag/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/subdag/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/subdag_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/subdag_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/trigger_dagrun/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/trigger_dagrun/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/weekday/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/operators/weekday/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/base_secrets/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/base_secrets/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/environment_variables/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/environment_variables/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/local_filesystem/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/local_filesystem/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/metastore/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/secrets/metastore/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/base/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/base/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/base_sensor_operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/base_sensor_operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/bash/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/bash/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/date_time/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/date_time/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/date_time_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/date_time_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/external_task/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/external_task/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/external_task_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/external_task_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/filesystem/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/filesystem/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/hdfs_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/hdfs_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/hive_partition_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/hive_partition_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/http_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/http_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/metastore_partition_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/metastore_partition_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/named_hive_partition_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/named_hive_partition_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/python/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/python/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/s3_key_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/s3_key_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/s3_prefix_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/s3_prefix_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/smart_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/smart_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/sql/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/sql/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/sql_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/sql_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/time_delta/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/time_delta/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/time_delta_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/time_delta_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/time_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/time_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/web_hdfs_sensor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/web_hdfs_sensor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/weekday/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_api/airflow/sensors/weekday/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_bash_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_bash_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_branch_datetime_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_branch_datetime_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_branch_day_of_week_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_branch_day_of_week_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_branch_labels.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_branch_labels.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_dag_decorator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_dag_decorator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_external_task_marker_dag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_external_task_marker_dag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_kubernetes_executor_config.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_kubernetes_executor_config.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_latest_only_with_trigger.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_latest_only_with_trigger.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_python_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/example_python_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/subdags/subdag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/subdags/subdag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial_etl_dag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial_etl_dag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial_taskflow_api_etl.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial_taskflow_api_etl.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/exceptions.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/exceptions.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/base_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/base_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/celery_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/celery_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/celery_kubernetes_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/celery_kubernetes_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/dask_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/dask_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/debug_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/debug_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/executor_constants.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/executor_constants.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/executor_loader.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/executor_loader.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/kubernetes_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/kubernetes_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/local_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/local_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/sequential_executor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/executors/sequential_executor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/base.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/base.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/dbapi.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/dbapi.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/filesystem.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/filesystem.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/subprocess.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/hooks/subprocess.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/macros.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/macros.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/macros/hive.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/macros/hive.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/base.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/base.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/baseoperator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/baseoperator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/connection.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/connection.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/crypto.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/crypto.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagbag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagbag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagcode.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagcode.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagparam.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagparam.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagpickle.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagpickle.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagrun.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/dagrun.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/errors.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/errors.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/log.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/log.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/pool.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/pool.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/renderedtifields.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/renderedtifields.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/sensorinstance.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/sensorinstance.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/serialized_dag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/serialized_dag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/skipmixin.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/skipmixin.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/slamiss.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/slamiss.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskfail.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskfail.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskinstance.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskinstance.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskmixin.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskmixin.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskreschedule.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/taskreschedule.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/variable.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/variable.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/xcom.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/xcom.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/xcom_arg.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/models/xcom_arg.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/bash.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/bash.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/branch.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/branch.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/check_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/check_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/datetime.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/datetime.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/dummy.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/dummy.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/email.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/email.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/generic_transfer.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/generic_transfer.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/google_api_to_s3_transfer.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/google_api_to_s3_transfer.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/hive_to_druid.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/hive_to_druid.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/hive_to_mysql.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/hive_to_mysql.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/latest_only.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/latest_only.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/mssql_to_hive.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/mssql_to_hive.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/mysql_to_hive.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/mysql_to_hive.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/presto_check_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/presto_check_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/presto_to_mysql.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/presto_to_mysql.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/python.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/python.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/redshift_to_s3_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/redshift_to_s3_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/s3_to_hive_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/s3_to_hive_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/s3_to_redshift_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/s3_to_redshift_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/sql.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/sql.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/sql_branch_operator.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/sql_branch_operator.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/subdag.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/subdag.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/trigger_dagrun.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/trigger_dagrun.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/weekday.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/operators/weekday.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/base_secrets.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/base_secrets.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/environment_variables.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/environment_variables.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/local_filesystem.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/local_filesystem.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/metastore.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/secrets/metastore.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/base.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/base.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/bash.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/bash.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/date_time.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/date_time.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/external_task.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/external_task.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/filesystem.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/filesystem.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/python.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/python.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/smart_sensor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/smart_sensor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/sql.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/sql.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/time_delta.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/time_delta.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/time_sensor.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/time_sensor.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/weekday.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/sensors/weekday.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/airflow/www/security.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/airflow/www/security.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/_modules/index.html
+++ b/docs-archive/apache-airflow/2.1.2/_modules/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/best-practices.html
+++ b/docs-archive/apache-airflow/2.1.2/best-practices.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/changelog.html
+++ b/docs-archive/apache-airflow/2.1.2/changelog.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/cli-and-env-variables-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/cli-and-env-variables-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/cluster-policies.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/cluster-policies.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/connections.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/connections.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/dags.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/dags.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/index.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/operators.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/operators.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/overview.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/overview.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/pools.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/pools.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/priority-weight.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/priority-weight.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/scheduler.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/scheduler.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/sensors.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/sensors.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/smart-sensors.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/smart-sensors.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/taskflow.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/taskflow.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/tasks.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/tasks.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/variables.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/variables.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/concepts/xcoms.html
+++ b/docs-archive/apache-airflow/2.1.2/concepts/xcoms.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/configurations-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/configurations-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/dag-run.html
+++ b/docs-archive/apache-airflow/2.1.2/dag-run.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/dag-serialization.html
+++ b/docs-archive/apache-airflow/2.1.2/dag-serialization.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/deprecated-rest-api-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/deprecated-rest-api-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/celery.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/celery.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/celery_kubernetes.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/celery_kubernetes.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/dask.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/dask.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/debug.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/debug.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/index.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/kubernetes.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/kubernetes.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/local.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/local.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/executor/sequential.html
+++ b/docs-archive/apache-airflow/2.1.2/executor/sequential.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/extra-packages-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/extra-packages-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/faq.html
+++ b/docs-archive/apache-airflow/2.1.2/faq.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/genindex.html
+++ b/docs-archive/apache-airflow/2.1.2/genindex.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/add-dag-tags.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/add-dag-tags.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/connection.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/connection.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/custom-operator.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/custom-operator.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/customize-dag-ui-page-instance-name.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/customize-dag-ui-page-instance-name.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/customize-state-colors-ui.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/customize-state-colors-ui.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/define_extra_link.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/define_extra_link.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/email-config.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/email-config.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/index.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/operator/bash.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/operator/bash.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/operator/datetime.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/operator/datetime.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/operator/external_task_sensor.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/operator/external_task_sensor.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/operator/index.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/operator/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/operator/python.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/operator/python.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/operator/weekday.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/operator/weekday.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/run-behind-proxy.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/run-behind-proxy.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/run-with-systemd.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/run-with-systemd.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/run-with-upstart.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/run-with-upstart.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/set-config.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/set-config.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/set-up-database.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/set-up-database.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/use-test-config.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/use-test-config.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/howto/variable.html
+++ b/docs-archive/apache-airflow/2.1.2/howto/variable.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/http-routingtable.html
+++ b/docs-archive/apache-airflow/2.1.2/http-routingtable.html
@@ -37,8 +37,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/index.html
+++ b/docs-archive/apache-airflow/2.1.2/index.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/installation.html
+++ b/docs-archive/apache-airflow/2.1.2/installation.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/integration.html
+++ b/docs-archive/apache-airflow/2.1.2/integration.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/kubernetes.html
+++ b/docs-archive/apache-airflow/2.1.2/kubernetes.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/license.html
+++ b/docs-archive/apache-airflow/2.1.2/license.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/lineage.html
+++ b/docs-archive/apache-airflow/2.1.2/lineage.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/check-health.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/check-health.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/errors.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/errors.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/index.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/logging-architecture.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/logging-architecture.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/logging-tasks.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/logging-tasks.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/metrics.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/metrics.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/logging-monitoring/tracking-user-activity.html
+++ b/docs-archive/apache-airflow/2.1.2/logging-monitoring/tracking-user-activity.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/macros-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/macros-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/migrations-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/migrations-ref.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/modules_management.html
+++ b/docs-archive/apache-airflow/2.1.2/modules_management.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/operators-and-hooks-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/operators-and-hooks-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/plugins.html
+++ b/docs-archive/apache-airflow/2.1.2/plugins.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/privacy_notice.html
+++ b/docs-archive/apache-airflow/2.1.2/privacy_notice.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/production-deployment.html
+++ b/docs-archive/apache-airflow/2.1.2/production-deployment.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/project.html
+++ b/docs-archive/apache-airflow/2.1.2/project.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/py-modindex.html
+++ b/docs-archive/apache-airflow/2.1.2/py-modindex.html
@@ -33,8 +33,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/python-api-ref.html
+++ b/docs-archive/apache-airflow/2.1.2/python-api-ref.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/release-process.html
+++ b/docs-archive/apache-airflow/2.1.2/release-process.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/search.html
+++ b/docs-archive/apache-airflow/2.1.2/search.html
@@ -33,8 +33,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/access-control.html
+++ b/docs-archive/apache-airflow/2.1.2/security/access-control.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/api.html
+++ b/docs-archive/apache-airflow/2.1.2/security/api.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/flower.html
+++ b/docs-archive/apache-airflow/2.1.2/security/flower.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/index.html
+++ b/docs-archive/apache-airflow/2.1.2/security/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/kerberos.html
+++ b/docs-archive/apache-airflow/2.1.2/security/kerberos.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/secrets/fernet.html
+++ b/docs-archive/apache-airflow/2.1.2/security/secrets/fernet.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/secrets/index.html
+++ b/docs-archive/apache-airflow/2.1.2/security/secrets/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/secrets/secrets-backend/index.html
+++ b/docs-archive/apache-airflow/2.1.2/security/secrets/secrets-backend/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/secrets/secrets-backend/local-filesystem-secrets-backend.html
+++ b/docs-archive/apache-airflow/2.1.2/security/secrets/secrets-backend/local-filesystem-secrets-backend.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/webserver.html
+++ b/docs-archive/apache-airflow/2.1.2/security/webserver.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/security/workload.html
+++ b/docs-archive/apache-airflow/2.1.2/security/workload.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/start/docker.html
+++ b/docs-archive/apache-airflow/2.1.2/start/docker.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/start/index.html
+++ b/docs-archive/apache-airflow/2.1.2/start/index.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/start/local.html
+++ b/docs-archive/apache-airflow/2.1.2/start/local.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/timezone.html
+++ b/docs-archive/apache-airflow/2.1.2/timezone.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/tutorial.html
+++ b/docs-archive/apache-airflow/2.1.2/tutorial.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/tutorial_taskflow_api.html
+++ b/docs-archive/apache-airflow/2.1.2/tutorial_taskflow_api.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/ui.html
+++ b/docs-archive/apache-airflow/2.1.2/ui.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/upgrade-check.html
+++ b/docs-archive/apache-airflow/2.1.2/upgrade-check.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/upgrading-to-2.html
+++ b/docs-archive/apache-airflow/2.1.2/upgrading-to-2.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/apache-airflow/2.1.2/usage-cli.html
+++ b/docs-archive/apache-airflow/2.1.2/usage-cli.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/_modules/docs/docker-stack/docker-examples/extending/embedding-dags/test_dag.html
+++ b/docs-archive/docker-stack/_modules/docs/docker-stack/docker-examples/extending/embedding-dags/test_dag.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/_modules/index.html
+++ b/docs-archive/docker-stack/_modules/index.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/build-arg-ref.html
+++ b/docs-archive/docker-stack/build-arg-ref.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/build.html
+++ b/docs-archive/docker-stack/build.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/entrypoint.html
+++ b/docs-archive/docker-stack/entrypoint.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/genindex.html
+++ b/docs-archive/docker-stack/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/index.html
+++ b/docs-archive/docker-stack/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/recipes.html
+++ b/docs-archive/docker-stack/recipes.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/docker-stack/search.html
+++ b/docs-archive/docker-stack/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/adding-connections-and-variables.html
+++ b/docs-archive/helm-chart/1.1.0/adding-connections-and-variables.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/airflow-configuration.html
+++ b/docs-archive/helm-chart/1.1.0/airflow-configuration.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/changelog.html
+++ b/docs-archive/helm-chart/1.1.0/changelog.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/genindex.html
+++ b/docs-archive/helm-chart/1.1.0/genindex.html
@@ -29,8 +29,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/index.html
+++ b/docs-archive/helm-chart/1.1.0/index.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/keda.html
+++ b/docs-archive/helm-chart/1.1.0/keda.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/manage-dags-files.html
+++ b/docs-archive/helm-chart/1.1.0/manage-dags-files.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/manage-logs.html
+++ b/docs-archive/helm-chart/1.1.0/manage-logs.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/parameters-ref.html
+++ b/docs-archive/helm-chart/1.1.0/parameters-ref.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/production-guide.html
+++ b/docs-archive/helm-chart/1.1.0/production-guide.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/quick-start.html
+++ b/docs-archive/helm-chart/1.1.0/quick-start.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/search.html
+++ b/docs-archive/helm-chart/1.1.0/search.html
@@ -32,8 +32,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/updating.html
+++ b/docs-archive/helm-chart/1.1.0/updating.html
@@ -30,8 +30,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">

--- a/docs-archive/helm-chart/1.1.0/using-additional-containers.html
+++ b/docs-archive/helm-chart/1.1.0/using-additional-containers.html
@@ -31,8 +31,7 @@
     
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">Airflow Summit 2021 is coming July 8-16. Register now!</a>
-    <nav class="js-navbar-scroll navbar" style="top: 40px;">
+        <nav class="js-navbar-scroll navbar">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">


### PR DESCRIPTION
Follow-up to #465. Removes the banner from the static HTML files that have been generated with the banner in them.