### PR TITLE
Fix Helm chart 1.2.0 binary sha512 link (#483)

### DIFF
--- a/docs-archive/helm-chart/1.2.0/_sources/installing-helm-chart-from-sources.rst.txt
+++ b/docs-archive/helm-chart/1.2.0/_sources/installing-helm-chart-from-sources.rst.txt
@@ -44,7 +44,7 @@ The downloads are available at:
 .. jinja:: official_download_page
 
     * `Sources package <{{ closer_lua_url }}/{{ package_version }}/airflow-chart-{{ package_version }}-source.tar.gz>`__ (`asc <{{ base_url }}/{{ package_version }}/airflow-chart-{{ package_version }}-source.tar.gz.asc>`__, `sha512 <{{ base_url }}/{{ package_version }}/airflow-chart-{{ package_version }}-source.tar.gz.sha512>`__)
-    * `Installable package <{{ closer_lua_url }}/{{ package_version }}/airflow-{{ package_version }}.tgz>`__ (`asc <{{ base_url }}/{{ package_version }}/airflow-{{ package_version }}.tgz.asc>`__, `sha512 <{{ base_url }}/{{ package_version }}/airflow-chart-{{ package_version }}.tgz.sha512>`__)
+    * `Installable package <{{ closer_lua_url }}/{{ package_version }}/airflow-{{ package_version }}.tgz>`__ (`asc <{{ base_url }}/{{ package_version }}/airflow-{{ package_version }}.tgz.asc>`__, `sha512 <{{ base_url }}/{{ package_version }}/airflow-{{ package_version }}.tgz.sha512>`__)
 
 If you want to install from the source code, you can download from the sources link above, it will contain
 a ``INSTALL`` file containing details on how you can build and install the chart.

--- a/docs-archive/helm-chart/1.2.0/installing-helm-chart-from-sources.html
+++ b/docs-archive/helm-chart/1.2.0/installing-helm-chart-from-sources.html
@@ -610,7 +610,7 @@ The packages are available via the
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/helm-chart/1.2.0/airflow-chart-1.2.0-source.tar.gz">Sources package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-chart-1.2.0-source.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-chart-1.2.0-source.tar.gz.sha512">sha512</a>)</p></li>
-<li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/helm-chart/1.2.0/airflow-1.2.0.tgz">Installable package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-1.2.0.tgz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-chart-1.2.0.tgz.sha512">sha512</a>)</p></li>
+<li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/helm-chart/1.2.0/airflow-1.2.0.tgz">Installable package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-1.2.0.tgz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-1.2.0.tgz.sha512">sha512</a>)</p></li>
 </ul>
 <p>If you want to install from the source code, you can download from the sources link above, it will contain
 a <code class="docutils literal notranslate"><span class="pre">INSTALL</span></code> file containing details on how you can build and install the chart.</p>


### PR DESCRIPTION
Missed fixing the sha512 link.