### PR TITLE
Rename Mirrors to Downloads for ASF sources

### DIFF
--- a/docs-archive/apache-airflow-providers-airbyte/2.1.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.1/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-airbyte-2.1.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-airbyte-2.1.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-airbyte-2.1.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-alibaba/1.0.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-alibaba/1.0.0/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-alibaba-1.0.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-alibaba-1.0.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-alibaba-1.0.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-amazon/2.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.3.0/installing-providers-from-sources.html
@@ -594,7 +594,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-amazon-2.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-amazon-2.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-amazon-2.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.1/installing-providers-from-sources.html
@@ -593,7 +593,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-beam-3.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-beam-3.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-beam-3.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-beam/3.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.1.0/installing-providers-from-sources.html
@@ -586,7 +586,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-beam-3.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-beam-3.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-beam-3.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.1.0/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-cassandra-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-cassandra-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-cassandra-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.1/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-drill-1.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-drill-1.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-drill-1.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.2/installing-providers-from-sources.html
@@ -582,7 +582,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-druid-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-druid-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-druid-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-hdfs/2.1.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-hdfs/2.1.1/installing-providers-from-sources.html
@@ -582,7 +582,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-hdfs-2.1.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-hdfs-2.1.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-hdfs-2.1.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/installing-providers-from-sources.html
@@ -595,7 +595,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-hive-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-hive-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-hive-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/installing-providers-from-sources.html
@@ -588,7 +588,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-hive-2.0.3.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-hive-2.0.3.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-hive-2.0.3.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-kylin-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-kylin-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-kylin-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.1.0/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-livy-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-livy-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-livy-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-pig-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-pig-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-pig-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-pinot/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-pinot/2.0.1/installing-providers-from-sources.html
@@ -572,7 +572,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-pinot-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-pinot-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-pinot-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.1/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-spark-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-spark-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-spark-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-apache-sqoop/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-apache-sqoop/2.0.2/installing-providers-from-sources.html
@@ -572,7 +572,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-apache-sqoop-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-sqoop-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-sqoop-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-asana/1.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-asana/1.1.0/installing-providers-from-sources.html
@@ -602,7 +602,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-asana-1.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-asana-1.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-asana-1.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-celery/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-celery/2.1.0/installing-providers-from-sources.html
@@ -572,7 +572,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-celery-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-celery-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-celery-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-cloudant/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-cloudant/2.0.1/installing-providers-from-sources.html
@@ -572,7 +572,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-cloudant-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-cloudant-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-cloudant-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.3/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.3/installing-providers-from-sources.html
@@ -599,7 +599,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-cncf-kubernetes-2.0.3.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-cncf-kubernetes-2.0.3.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-cncf-kubernetes-2.0.3.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.1.0/installing-providers-from-sources.html
@@ -592,7 +592,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-cncf-kubernetes-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-cncf-kubernetes-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-cncf-kubernetes-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-databricks/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.2/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-databricks-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-databricks-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-databricks-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-datadog/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-datadog/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-datadog-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-datadog-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-datadog-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-dingding/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.1/installing-providers-from-sources.html
@@ -588,7 +588,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-dingding-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-dingding-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-dingding-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-discord/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-discord/2.0.1/installing-providers-from-sources.html
@@ -572,7 +572,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-discord-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-discord-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-discord-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-docker/2.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-docker/2.2.0/installing-providers-from-sources.html
@@ -589,7 +589,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-docker-2.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-docker-2.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-docker-2.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-docker/2.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-docker/2.3.0/installing-providers-from-sources.html
@@ -582,7 +582,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-docker-2.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-docker-2.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-docker-2.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.3/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.3/installing-providers-from-sources.html
@@ -603,7 +603,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-elasticsearch-2.0.3.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-elasticsearch-2.0.3.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-elasticsearch-2.0.3.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.1.0/installing-providers-from-sources.html
@@ -596,7 +596,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-elasticsearch-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-elasticsearch-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-elasticsearch-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-exasol/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-exasol/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-exasol-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-exasol-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-exasol-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-facebook/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.0.1/installing-providers-from-sources.html
@@ -585,7 +585,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-facebook-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-facebook-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-facebook-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-facebook/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-facebook/2.1.0/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-facebook-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-facebook-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-facebook-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-ftp/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-ftp/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-ftp-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-ftp-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-ftp-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-google/6.0.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-google/6.0.0/installing-providers-from-sources.html
@@ -605,7 +605,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-google-6.0.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-google-6.0.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-google-6.0.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-google/6.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-google/6.1.0/installing-providers-from-sources.html
@@ -598,7 +598,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-google-6.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-google-6.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-google-6.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-grpc/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-grpc/2.0.1/installing-providers-from-sources.html
@@ -586,7 +586,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-grpc-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-grpc-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-grpc-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-hashicorp/2.1.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-hashicorp/2.1.1/installing-providers-from-sources.html
@@ -586,7 +586,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-hashicorp-2.1.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-hashicorp-2.1.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-hashicorp-2.1.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-http/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.1/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-http-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-http-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-http-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-imap/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-imap/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-imap-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-imap-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-imap-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-influxdb/1.0.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-influxdb/1.0.0/installing-providers-from-sources.html
@@ -610,7 +610,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-influxdb-1.0.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-influxdb-1.0.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-influxdb-1.0.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.1/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-jdbc-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jdbc-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jdbc-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.2/installing-providers-from-sources.html
@@ -587,7 +587,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-jenkins-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jenkins-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jenkins-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.3/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.3/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-jenkins-2.0.3.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jenkins-2.0.3.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jenkins-2.0.3.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-jira/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-jira/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-jira-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jira-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-jira-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.2.0/installing-providers-from-sources.html
@@ -601,7 +601,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-microsoft-azure-3.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-azure-3.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-azure-3.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.3.0/installing-providers-from-sources.html
@@ -594,7 +594,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-microsoft-azure-3.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-azure-3.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-azure-3.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-microsoft-mssql-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-mssql-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-mssql-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-microsoft-psrp/1.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-microsoft-psrp/1.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-microsoft-psrp-1.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-psrp-1.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-psrp-1.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-microsoft-winrm-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-winrm-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-microsoft-winrm-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-mongo/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.1.0/installing-providers-from-sources.html
@@ -587,7 +587,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-mongo-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-mongo-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-mongo-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-mongo/2.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-mongo/2.2.0/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-mongo-2.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-mongo-2.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-mongo-2.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-mysql/2.1.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.1/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-mysql-2.1.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-mysql-2.1.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-mysql-2.1.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.2/installing-providers-from-sources.html
@@ -596,7 +596,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-neo4j-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-neo4j-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-neo4j-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-odbc/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-odbc/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-odbc-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-odbc-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-odbc-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-openfaas/2.0.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-openfaas/2.0.0/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-openfaas-2.0.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-openfaas-2.0.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-openfaas-2.0.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-opsgenie/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-opsgenie-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-opsgenie-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-opsgenie-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-oracle/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-oracle/2.0.1/installing-providers-from-sources.html
@@ -586,7 +586,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-oracle-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-oracle-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-oracle-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-pagerduty/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.0.1/installing-providers-from-sources.html
@@ -585,7 +585,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-pagerduty-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-pagerduty-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-pagerduty-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-pagerduty/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-pagerduty/2.1.0/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-pagerduty-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-pagerduty-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-pagerduty-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-papermill/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.1.0/installing-providers-from-sources.html
@@ -588,7 +588,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-papermill-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-papermill-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-papermill-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-plexus/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.1/installing-providers-from-sources.html
@@ -586,7 +586,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-plexus-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-plexus-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-plexus-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-postgres/2.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.3.0/installing-providers-from-sources.html
@@ -596,7 +596,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-postgres-2.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-postgres-2.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-postgres-2.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-presto/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-presto/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-presto-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-presto-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-presto-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-qubole/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-qubole-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-qubole-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-qubole-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-redis/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-redis/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-redis-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-redis-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-redis-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-salesforce/3.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.2.0/installing-providers-from-sources.html
@@ -595,7 +595,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-salesforce-3.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-salesforce-3.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-salesforce-3.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-salesforce/3.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.3.0/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-salesforce-3.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-salesforce-3.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-salesforce-3.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-samba/3.0.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-samba/3.0.0/installing-providers-from-sources.html
@@ -585,7 +585,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-samba-3.0.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-samba-3.0.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-samba-3.0.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-samba/3.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-samba/3.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-samba-3.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-samba-3.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-samba-3.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-segment/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-segment/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-segment-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-segment-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-segment-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-sendgrid/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-sendgrid/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-sendgrid-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sendgrid-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sendgrid-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-sftp/2.1.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.1.1/installing-providers-from-sources.html
@@ -587,7 +587,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-sftp-2.1.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sftp-2.1.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sftp-2.1.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-sftp/2.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-sftp/2.2.0/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-sftp-2.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sftp-2.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sftp-2.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-singularity/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.1/installing-providers-from-sources.html
@@ -580,7 +580,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-singularity-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-singularity-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-singularity-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-slack/4.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-slack/4.1.0/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-slack-4.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-slack-4.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-slack-4.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-snowflake/2.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.2.0/installing-providers-from-sources.html
@@ -597,7 +597,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-snowflake-2.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-snowflake-2.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-snowflake-2.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-snowflake/2.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.3.0/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-snowflake-2.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-snowflake-2.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-snowflake-2.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.1/installing-providers-from-sources.html
@@ -596,7 +596,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-sqlite-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sqlite-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-sqlite-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-ssh/2.2.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.2.0/installing-providers-from-sources.html
@@ -593,7 +593,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-ssh-2.2.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-ssh-2.2.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-ssh-2.2.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-ssh/2.3.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-ssh/2.3.0/installing-providers-from-sources.html
@@ -586,7 +586,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-ssh-2.3.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-ssh-2.3.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-ssh-2.3.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.1/installing-providers-from-sources.html
@@ -591,7 +591,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-tableau-2.1.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-tableau-2.1.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-tableau-2.1.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.2/installing-providers-from-sources.html
@@ -584,7 +584,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-tableau-2.1.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-tableau-2.1.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-tableau-2.1.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-telegram/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.1/installing-providers-from-sources.html
@@ -588,7 +588,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-telegram-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-telegram-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-telegram-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-trino/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.1/installing-providers-from-sources.html
@@ -585,7 +585,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-trino-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-trino-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-trino-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-trino/2.0.2/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-trino/2.0.2/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-trino-2.0.2.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-trino-2.0.2.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-trino-2.0.2.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-vertica/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-vertica/2.0.1/installing-providers-from-sources.html
@@ -578,7 +578,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-vertica-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-vertica-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-vertica-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-yandex/2.1.0/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.1.0/installing-providers-from-sources.html
@@ -590,7 +590,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-yandex-2.1.0.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-yandex-2.1.0.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-yandex-2.1.0.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow-providers-zendesk/2.0.1/installing-providers-from-sources.html
+++ b/docs-archive/apache-airflow-providers-zendesk/2.0.1/installing-providers-from-sources.html
@@ -572,7 +572,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/providers/apache-airflow-providers-zendesk-2.0.1.tar.gz">Sdist package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-zendesk-2.0.1.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/providers/apache-airflow-providers-zendesk-2.0.1.tar.gz.sha512">sha512</a>) - those are also official sources for the package</p></li>

--- a/docs-archive/apache-airflow/2.1.4/_sources/installation/installing-from-sources.rst.txt
+++ b/docs-archive/apache-airflow/2.1.4/_sources/installation/installing-from-sources.rst.txt
@@ -35,7 +35,7 @@ Released packages
 The ``source``, ``sdist`` and ``whl`` packages released are the "official" sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`_
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 
 The |version| downloads are available at:

--- a/docs-archive/apache-airflow/2.1.4/installation/installing-from-sources.html
+++ b/docs-archive/apache-airflow/2.1.4/installation/installing-from-sources.html
@@ -685,7 +685,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">source</span></code>, <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the “official” sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The 2.1.4 downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/2.1.4/apache-airflow-2.1.4-source.tar.gz">Sources package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/2.1.4/apache-airflow-2.1.4-source.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/2.1.4/apache-airflow-2.1.4-source.tar.gz.sha512">sha512</a>)</p></li>

--- a/docs-archive/apache-airflow/2.2.0/_sources/installation/installing-from-sources.rst.txt
+++ b/docs-archive/apache-airflow/2.2.0/_sources/installation/installing-from-sources.rst.txt
@@ -32,7 +32,7 @@ Released packages
 The ``source``, ``sdist`` and ``whl`` packages released are the "official" sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`_
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 
 The |version| downloads are available at:

--- a/docs-archive/apache-airflow/2.2.0/installation/installing-from-sources.html
+++ b/docs-archive/apache-airflow/2.2.0/installation/installing-from-sources.html
@@ -678,7 +678,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">source</span></code>, <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The 2.2.0 downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/2.2.0/apache-airflow-2.2.0-source.tar.gz">Sources package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/2.2.0/apache-airflow-2.2.0-source.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/2.2.0/apache-airflow-2.2.0-source.tar.gz.sha512">sha512</a>)</p></li>

--- a/docs-archive/apache-airflow/2.2.1/_sources/installation/installing-from-sources.rst.txt
+++ b/docs-archive/apache-airflow/2.2.1/_sources/installation/installing-from-sources.rst.txt
@@ -32,7 +32,7 @@ Released packages
 The ``source``, ``sdist`` and ``whl`` packages released are the "official" sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`_
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 
 The |version| downloads are available at:

--- a/docs-archive/apache-airflow/2.2.1/installation/installing-from-sources.html
+++ b/docs-archive/apache-airflow/2.2.1/installation/installing-from-sources.html
@@ -678,7 +678,7 @@ the top-left of the page.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">source</span></code>, <code class="docutils literal notranslate"><span class="pre">sdist</span></code> and <code class="docutils literal notranslate"><span class="pre">whl</span></code> packages released are the &quot;official&quot; sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The 2.2.1 downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/2.2.1/apache-airflow-2.2.1-source.tar.gz">Sources package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/2.2.1/apache-airflow-2.2.1-source.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/2.2.1/apache-airflow-2.2.1-source.tar.gz.sha512">sha512</a>)</p></li>

--- a/docs-archive/helm-chart/1.2.0/_sources/installing-helm-chart-from-sources.rst.txt
+++ b/docs-archive/helm-chart/1.2.0/_sources/installing-helm-chart-from-sources.rst.txt
@@ -37,7 +37,7 @@ Released packages
 The sources and packages released are the "official" sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`_
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 The downloads are available at:
 

--- a/docs-archive/helm-chart/1.2.0/installing-helm-chart-from-sources.html
+++ b/docs-archive/helm-chart/1.2.0/installing-helm-chart-from-sources.html
@@ -606,7 +606,7 @@ the top-left of the page.</p>
 <p>The sources and packages released are the “official” sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Mirrors</a></p>
+<a class="reference external" href="http://ws.apache.org/mirrors.cgi">Official Apache Software Foundations Downloads</a></p>
 <p>The downloads are available at:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="https://www.apache.org/dyn/closer.lua/airflow/helm-chart/1.2.0/airflow-chart-1.2.0-source.tar.gz">Sources package</a> (<a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-chart-1.2.0-source.tar.gz.asc">asc</a>, <a class="reference external" href="https://downloads.apache.org/airflow/helm-chart/1.2.0/airflow-chart-1.2.0-source.tar.gz.sha512">sha512</a>)</p></li>


### PR DESCRIPTION
The ASF used to use mirrors to distribute their software, however
recently they changed to use CDN. The mechanism might change in
the future (even if currently CDN is used the ASF 'mirrors' page
and closer.lua script provide a fully ASF-controlled mechanism to
switch to the right mechanism, however technically speaking the
current solution is not 'mirrors' but it is CDN, therefore it makes
sense to rename it to generic downloads.