### PR TITLE
minor: add workflow build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Apache Airflow website
 ======================
 
-[![Build Status](https://travis-ci.org/apache/airflow-site.svg)](https://travis-ci.org/apache/airflow-site)
+[![Build Status](https://api.travis-ci.com/apache/airflow-site.svg)](https://travis-ci.com/apache/airflow-site)
 
 This is a repository of [Apache Airflow website](https://airflow.apache.org).
 The repository of Apache Airflow can be found [here](https://github.com/apache/airflow/).


### PR DESCRIPTION
seems the builds still are no more available on travis-ci.com

