### PR TITLE
Add redirect for broken upgrading link in 2.2.2

### DIFF
--- a/docs-archive/apache-airflow/2.2.2/installing/upgrading.html
+++ b/docs-archive/apache-airflow/2.2.2/installing/upgrading.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=../installation/upgrading.html"/></head></html>


### PR DESCRIPTION
This will be fixed in 2.2.3, but we should add a redirect so the
existing 2.2.2 installs in the wild aren't broken.

Details: https://github.com/apache/airflow/pull/19837