### PR TITLE
Put copy button within code block

### DIFF
--- a/landing-pages/site/assets/scss/_highlights.scss
+++ b/landing-pages/site/assets/scss/_highlights.scss
@@ -88,8 +88,7 @@ pre {
   padding: 16px 20px;
   border: solid 1px map-get($colors, very-light-pink);
   border-radius: 5px;
-  width: fit-content;
-  max-width: 100%;
+  width: 100%;
 
   span {
     @extend .monotext--brownish-grey;


### PR DESCRIPTION
This is an attempt to address part of #324 (I'm not seeing the 404 that was also mentioned but happy to take a look at that as well if someone can point it out). 

It looks to me like the reason the copy button is in the correct place e.g. [here](https://airflow.apache.org/docs/apache-airflow/stable/tutorial.html) is that the `width: fit-content` on the pre elements is getting overridden by a `width: unset` from the `example-block-wrapper` class. So setting `width: 100%` appears to solve the problem, though there may be a better way to approach this.