### PR TITLE
Use safe API to get target element

### DIFF
--- a/landing-pages/src/js/progressTracking.js
+++ b/landing-pages/src/js/progressTracking.js
@@ -31,7 +31,7 @@ const runProgressTracking = () => {
     const target = hash.substr(1);
     let targetElement;
     if (target) {
-      targetElement = document.querySelector(`#${target}`);
+      targetElement = document.getElementById(target);
     } else {
       targetElement = document.body;
     }


### PR DESCRIPTION
As highlighted by @mik-laj in issue #361, the target string sometimes contains a period (".") character which makes `querySelector` match on a class which is wrong in this case.

Regardless of whether it fixes the issue, this change is a good one.