### PR TITLE
Remove dbt-cloud provider for now

### DIFF
--- a/docs-archive/apache-airflow-providers/core-extensions/connections.html
+++ b/docs-archive/apache-airflow-providers/core-extensions/connections.html
@@ -663,12 +663,6 @@ provided by the community-managed providers:</p>
 <li><p><cite>databricks</cite>: <a class="reference external" href="/docs/apache-airflow-providers-databricks/stable/_api/airflow/providers/databricks/hooks/databricks_sql/index.html#airflow.providers.databricks.hooks.databricks_sql.DatabricksSqlHook" title="(in apache-airflow-providers-databricks v2.3.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">DatabricksSqlHook</span></code></a></p></li>
 </ul>
 </div>
-<div class="section" id="dbt-cloud">
-<h2>dbt Cloud<a class="headerlink" href="#dbt-cloud" title="Permalink to this headline">¶</a></h2>
-<ul class="simple">
-<li><p><cite>dbt_cloud</cite>: <a class="reference external" href="/docs/apache-airflow-providers-dbt-cloud/stable/_api/airflow/providers/dbt/cloud/hooks/dbt/index.html#airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook" title="(in apache-airflow-providers-dbt-cloud v1.0.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">DbtCloudHook</span></code></a></p></li>
-</ul>
-</div>
 <div class="section" id="dingding">
 <h2>Dingding<a class="headerlink" href="#dingding" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
@@ -1032,7 +1026,6 @@ provided by the community-managed providers:</p>
 <li><a class="reference internal" href="#ibm-cloudant">IBM Cloudant</a></li>
 <li><a class="reference internal" href="#kubernetes">Kubernetes</a></li>
 <li><a class="reference internal" href="#databricks">Databricks</a></li>
-<li><a class="reference internal" href="#dbt-cloud">dbt Cloud</a></li>
 <li><a class="reference internal" href="#dingding">Dingding</a></li>
 <li><a class="reference internal" href="#discord">Discord</a></li>
 <li><a class="reference internal" href="#docker">Docker</a></li>

--- a/docs-archive/apache-airflow-providers/core-extensions/extra-links.html
+++ b/docs-archive/apache-airflow-providers/core-extensions/extra-links.html
@@ -564,12 +564,6 @@ provided by the community-managed providers:</p>
 <li><p><code class="xref py py-class docutils literal notranslate"><span class="pre">EmrClusterLink</span></code></p></li>
 </ul>
 </div>
-<div class="section" id="dbt-cloud">
-<h2>dbt Cloud<a class="headerlink" href="#dbt-cloud" title="Permalink to this headline">¶</a></h2>
-<ul class="simple">
-<li><p><a class="reference external" href="/docs/apache-airflow-providers-dbt-cloud/stable/_api/airflow/providers/dbt/cloud/operators/dbt/index.html#airflow.providers.dbt.cloud.operators.dbt.DbtCloudRunJobOperatorLink" title="(in apache-airflow-providers-dbt-cloud v1.0.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">DbtCloudRunJobOperatorLink</span></code></a></p></li>
-</ul>
-</div>
 <div class="section" id="google">
 <h2>Google<a class="headerlink" href="#google" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
@@ -684,7 +678,6 @@ provided by the community-managed providers:</p>
             <ul>
 <li><a class="reference internal" href="#">Extra Links</a><ul>
 <li><a class="reference internal" href="#amazon">Amazon</a></li>
-<li><a class="reference internal" href="#dbt-cloud">dbt Cloud</a></li>
 <li><a class="reference internal" href="#google">Google</a></li>
 <li><a class="reference internal" href="#microsoft-azure">Microsoft Azure</a></li>
 <li><a class="reference internal" href="#qubole">Qubole</a></li>

--- a/docs-archive/apache-airflow-providers/core-extensions/index.html
+++ b/docs-archive/apache-airflow-providers/core-extensions/index.html
@@ -572,7 +572,6 @@ core by implementations of Core features, specific to certain providers.</p>
 <li class="toctree-l2"><a class="reference internal" href="connections.html#ibm-cloudant">IBM Cloudant</a></li>
 <li class="toctree-l2"><a class="reference internal" href="connections.html#kubernetes">Kubernetes</a></li>
 <li class="toctree-l2"><a class="reference internal" href="connections.html#databricks">Databricks</a></li>
-<li class="toctree-l2"><a class="reference internal" href="connections.html#dbt-cloud">dbt Cloud</a></li>
 <li class="toctree-l2"><a class="reference internal" href="connections.html#dingding">Dingding</a></li>
 <li class="toctree-l2"><a class="reference internal" href="connections.html#discord">Discord</a></li>
 <li class="toctree-l2"><a class="reference internal" href="connections.html#docker">Docker</a></li>
@@ -619,7 +618,6 @@ core by implementations of Core features, specific to certain providers.</p>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="extra-links.html">Extra Links</a><ul>
 <li class="toctree-l2"><a class="reference internal" href="extra-links.html#amazon">Amazon</a></li>
-<li class="toctree-l2"><a class="reference internal" href="extra-links.html#dbt-cloud">dbt Cloud</a></li>
 <li class="toctree-l2"><a class="reference internal" href="extra-links.html#google">Google</a></li>
 <li class="toctree-l2"><a class="reference internal" href="extra-links.html#microsoft-azure">Microsoft Azure</a></li>
 <li class="toctree-l2"><a class="reference internal" href="extra-links.html#qubole">Qubole</a></li>

--- a/docs-archive/apache-airflow-providers/installing-from-sources.html
+++ b/docs-archive/apache-airflow-providers/installing-from-sources.html
@@ -587,8 +587,6 @@
 
     <li><a href="/docs/apache-airflow-providers-datadog/stable/installing-providers-from-sources.html"><code>Datadog</code></a></li>
 
-    <li><a href="/docs/apache-airflow-providers-dbt-cloud/stable/installing-providers-from-sources.html"><code>dbt Cloud</code></a></li>
-
     <li><a href="/docs/apache-airflow-providers-dingding/stable/installing-providers-from-sources.html"><code>Dingding</code></a></li>
 
     <li><a href="/docs/apache-airflow-providers-discord/stable/installing-providers-from-sources.html"><code>Discord</code></a></li>

--- a/docs-archive/apache-airflow-providers/packages-ref.html
+++ b/docs-archive/apache-airflow-providers/packages-ref.html
@@ -325,7 +325,6 @@
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-cncf-kubernetes"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-cncf-kubernetes</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-databricks"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-databricks</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-datadog"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-datadog</span></code></a></li>
-<li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-dbt-cloud"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dbt-cloud</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-dingding"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dingding</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-discord"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-discord</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-docker"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-docker</span></code></a></li>
@@ -519,7 +518,6 @@
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-cncf-kubernetes"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-cncf-kubernetes</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-databricks"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-databricks</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-datadog"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-datadog</span></code></a></li>
-<li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-dbt-cloud"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dbt-cloud</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-dingding"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dingding</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-discord"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-discord</span></code></a></li>
 <li class="toctree-l2"><a class="reference internal" href="#apache-airflow-providers-docker"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-docker</span></code></a></li>
@@ -707,7 +705,6 @@
 <li><p><a class="reference internal" href="#apache-airflow-providers-cncf-kubernetes" id="id19"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-cncf-kubernetes</span></code></a></p></li>
 <li><p><a class="reference internal" href="#apache-airflow-providers-databricks" id="id20"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-databricks</span></code></a></p></li>
 <li><p><a class="reference internal" href="#apache-airflow-providers-datadog" id="id21"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-datadog</span></code></a></p></li>
-<li><p><a class="reference internal" href="#apache-airflow-providers-dbt-cloud" id="id22"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dbt-cloud</span></code></a></p></li>
 <li><p><a class="reference internal" href="#apache-airflow-providers-dingding" id="id23"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dingding</span></code></a></p></li>
 <li><p><a class="reference internal" href="#apache-airflow-providers-discord" id="id24"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-discord</span></code></a></p></li>
 <li><p><a class="reference internal" href="#apache-airflow-providers-docker" id="id25"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-docker</span></code></a></p></li>
@@ -1158,25 +1155,6 @@ and <a class="reference external" href="https://hadoop.apache.org/docs/current/h
 </dd>
 <dt class="field-odd">Python API Reference</dt>
 <dd class="field-odd"><p><a class="reference external" href="/docs/apache-airflow-providers-datadog/stable/_api/airflow/providers/datadog/index.html#module-airflow.providers.datadog" title="(in apache-airflow-providers-datadog v2.0.2)"><code class="xref py py-mod docutils literal notranslate"><span class="pre">airflow.providers.datadog</span></code></a></p>
-</dd>
-</dl>
-</div>
-<div class="section" id="apache-airflow-providers-dbt-cloud">
-<span id="std-provider-apache-airflow-providers-dbt-cloud"></span><span id="std:provider-apache-airflow-providers-dbt-cloud"></span><h2><a class="toc-backref" href="#id22"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dbt-cloud</span></code></a><a class="headerlink" href="#apache-airflow-providers-dbt-cloud" title="Permalink to this headline">¶</a></h2>
-<p><a class="reference external" href="https://www.getdbt.com/product/what-is-dbt/">dbt Cloud</a>).</p>
-<p>To install, run:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip install <span class="s1">&#39;apache-airflow-providers-dbt-cloud&#39;</span>
-</pre></div>
-</div>
-<dl class="field-list simple">
-<dt class="field-odd">Available versions</dt>
-<dd class="field-odd"><p><code class="docutils literal notranslate"><span class="pre">1.0.0</span></code>.</p>
-</dd>
-<dt class="field-even">Reference</dt>
-<dd class="field-even"><p><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></p>
-</dd>
-<dt class="field-odd">Python API Reference</dt>
-<dd class="field-odd"><p><a class="reference external" href="/docs/apache-airflow-providers-dbt-cloud/stable/_api/airflow/providers/dbt/cloud/index.html#module-airflow.providers.dbt.cloud" title="(in apache-airflow-providers-dbt-cloud v1.0.0)"><code class="xref py py-mod docutils literal notranslate"><span class="pre">airflow.providers.dbt.cloud</span></code></a></p>
 </dd>
 </dl>
 </div>
@@ -2259,7 +2237,6 @@ and <a class="reference external" href="https://hadoop.apache.org/docs/current/h
 <li><a class="reference internal" href="#apache-airflow-providers-cncf-kubernetes"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-cncf-kubernetes</span></code></a></li>
 <li><a class="reference internal" href="#apache-airflow-providers-databricks"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-databricks</span></code></a></li>
 <li><a class="reference internal" href="#apache-airflow-providers-datadog"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-datadog</span></code></a></li>
-<li><a class="reference internal" href="#apache-airflow-providers-dbt-cloud"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dbt-cloud</span></code></a></li>
 <li><a class="reference internal" href="#apache-airflow-providers-dingding"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-dingding</span></code></a></li>
 <li><a class="reference internal" href="#apache-airflow-providers-discord"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-discord</span></code></a></li>
 <li><a class="reference internal" href="#apache-airflow-providers-docker"><code class="docutils literal notranslate"><span class="pre">apache-airflow-providers-docker</span></code></a></li>


### PR DESCRIPTION
The dbt provider has been deferred to RC2 release and should be
removed from the index.

Fixes: https://github.com/apache/airflow/issues/22197