### PR TITLE
Update community page to include GitHub discussions

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -29,14 +29,26 @@ menu:
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Report a bug" description="Use our [GitHub](https://github.com/apache/airflow/issues) to create a ticket." logo_path="icons/bug-icon.svg" >}}
+    {{< accordion title="Start a discussion" description="Use our [GitHub Discussions](https://github.com/apache/airflow/discussions) to start a discussion." logo_path="icons/ask-question-icon.svg" >}}
+    <p class="bodytext__medium--brownish-grey">You can start discussions about anything:</p>
+    <ul class="ticks-blue mx-auto">
+        <li>propose a new feature,</li>
+        <li>discuss if what you observe is a real issue,</li>
+        <li>generally brainstorm about your ideas,</li>
+        <li>ask others how they solve their problems,</li>
+    </ul>
+    {{< /accordion >}}
+
+    {{< accordion title="Report a bug" description="Use our [GitHub Issue](https://github.com/apache/airflow/issues) to create an issue." logo_path="icons/bug-icon.svg" >}}
     <p class="bodytext__medium--brownish-grey">Remember to put there as much information as you can, including:</p>
     <ul class="ticks-blue mx-auto">
         <li>tracebacks,</li>
         <li>screens,</li>
-        <li>scenarios to repeat problem.</li>
+        <li>scenarios to repeat problem (mandatory),</li>
+        <li>if you are unsure if this is a problem with Airflow - start a [GitHub Discussion](https://github.com/apache/airflow/discussions) first</li>
     </ul>
     {{< /accordion >}}
+
 
     {{< accordion title="Ask a question" description="In case of any questions or doubts, feel free to reach to our community. There are two ways to do that." logo_path="icons/ask-question-icon.svg" >}}
     <ol class="counter-blue mx-auto">


### PR DESCRIPTION
We have not updated our Community Page when we introduced
GitHub discussions. Sounds like it might be useful to
guide the people to open discussions when they want to
well, discuss something :)