### PR TITLE
Add warning to yanked cncf.kubernetes package documentation

### DIFF
--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.1/index.html
@@ -612,12 +612,18 @@
 <div class="section" id="package-apache-airflow-providers-cncf-kubernetes">
 <h2>Package apache-airflow-providers-cncf-kubernetes<a class="headerlink" href="#package-apache-airflow-providers-cncf-kubernetes" title="Permalink to this headline">¶</a></h2>
 <p><a class="reference external" href="https://kubernetes.io/">Kubernetes</a></p>
-<p>Release: 3.0.1</p>
+<p>Release: 3.0.1:  <span class="pre" style="color: red">THIS VERSION IS YANKED - DO NOT INSTALL IT (SEE WARNING BELOW)</span></code></p>
 </div>
 <div class="section" id="provider-package">
 <h2>Provider package<a class="headerlink" href="#provider-package" title="Permalink to this headline">¶</a></h2>
 <p>This is a provider package for <code class="docutils literal notranslate"><span class="pre">cncf.kubernetes</span></code> provider. All classes for this provider package
 are in <code class="docutils literal notranslate"><span class="pre">airflow.providers.cncf.kubernetes</span></code> python package.</p>
+</div>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>This version of the provider has been yanked as it had compatibility issues with core Airflow. Do not use this version. If you are on Airflow 2.1.* or 2.2.*, please downgrade the provider version to 3.0.0.</p>
+<p>Both core Airflow and the cncf.kubernetes provider use the kubernetes library, however, the kubernetes version used for the provider clashes with core Airflow dependencies. In Airflow 2.1.* and 2.2.* the latest working version of the provider is 3.0.0. The other 3.* versions of provider are "yanked" which means that they are skipped when installed unless you explicitly choose to install this version.</p>
+<p>Unless we see some serious bug to fix - all the future releases of the cncf.kubernetes provider (starting from 4.0.0) will only be installable for Airflow 2.3.* and above.</p>
 </div>
 <div class="section" id="installation">
 <h2>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h2>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.2/index.html
@@ -612,14 +612,19 @@
 <div class="section" id="package-apache-airflow-providers-cncf-kubernetes">
 <h2>Package apache-airflow-providers-cncf-kubernetes<a class="headerlink" href="#package-apache-airflow-providers-cncf-kubernetes" title="Permalink to this headline">¶</a></h2>
 <p><a class="reference external" href="https://kubernetes.io/">Kubernetes</a></p>
-<p>Release: 3.0.2</p>
+<p>Release: 3.0.2:  <span class="pre" style="color: red">THIS VERSION IS YANKED - DO NOT INSTALL IT (SEE WARNING BELOW)</span></code></p>
 </div>
 <div class="section" id="provider-package">
 <h2>Provider package<a class="headerlink" href="#provider-package" title="Permalink to this headline">¶</a></h2>
 <p>This is a provider package for <code class="docutils literal notranslate"><span class="pre">cncf.kubernetes</span></code> provider. All classes for this provider package
 are in <code class="docutils literal notranslate"><span class="pre">airflow.providers.cncf.kubernetes</span></code> python package.</p>
 </div>
-<div class="section" id="installation">
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>This version of the provider has been yanked as it had compatibility issues with core Airflow. Do not use this version. If you are on Airflow 2.1.* or 2.2.*, please downgrade the provider version to 3.0.0.</p>
+<p>Both core Airflow and the cncf.kubernetes provider use the kubernetes library, however, the kubernetes version used for the provider clashes with core Airflow dependencies. In Airflow 2.1.* and 2.2.* the latest working version of the provider is 3.0.0. The other 3.* versions of provider are "yanked" which means that they are skipped when installed unless you explicitly choose to install this version.</p>
+<p>Unless we see some serious bug to fix - all the future releases of the cncf.kubernetes provider (starting from 4.0.0) will only be installable for Airflow 2.3.* and above.</p>
+</div><div class="section" id="installation">
 <h2>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h2>
 <p>You can install this package on top of an existing Airflow 2.1+ installation via
 <code class="docutils literal notranslate"><span class="pre">pip</span> <span class="pre">install</span> <span class="pre">apache-airflow-providers-cncf-kubernetes</span></code></p>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.0/index.html
@@ -612,12 +612,18 @@
 <div class="section" id="package-apache-airflow-providers-cncf-kubernetes">
 <h2>Package apache-airflow-providers-cncf-kubernetes<a class="headerlink" href="#package-apache-airflow-providers-cncf-kubernetes" title="Permalink to this headline">¶</a></h2>
 <p><a class="reference external" href="https://kubernetes.io/">Kubernetes</a></p>
-<p>Release: 3.1.0</p>
+<p>Release: 3.1.0:  <span class="pre" style="color: red">THIS VERSION IS YANKED - DO NOT INSTALL IT (SEE WARNING BELOW)</span></code></p>
 </div>
 <div class="section" id="provider-package">
 <h2>Provider package<a class="headerlink" href="#provider-package" title="Permalink to this headline">¶</a></h2>
 <p>This is a provider package for <code class="docutils literal notranslate"><span class="pre">cncf.kubernetes</span></code> provider. All classes for this provider package
 are in <code class="docutils literal notranslate"><span class="pre">airflow.providers.cncf.kubernetes</span></code> python package.</p>
+</div>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>This version of the provider has been yanked as it had compatibility issues with core Airflow. Do not use this version. If you are on Airflow 2.1.* or 2.2.*, please downgrade the provider version to 3.0.0.</p>
+<p>Both core Airflow and the cncf.kubernetes provider use the kubernetes library, however, the kubernetes version used for the provider clashes with core Airflow dependencies. In Airflow 2.1.* and 2.2.* the latest working version of the provider is 3.0.0. The other 3.* versions of provider are "yanked" which means that they are skipped when installed unless you explicitly choose to install this version.</p>
+<p>Unless we see some serious bug to fix - all the future releases of the cncf.kubernetes provider (starting from 4.0.0) will only be installable for Airflow 2.3.* and above.</p>
 </div>
 <div class="section" id="installation">
 <h2>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h2>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.1/index.html
@@ -612,12 +612,18 @@
 <div class="section" id="package-apache-airflow-providers-cncf-kubernetes">
 <h2>Package apache-airflow-providers-cncf-kubernetes<a class="headerlink" href="#package-apache-airflow-providers-cncf-kubernetes" title="Permalink to this headline">¶</a></h2>
 <p><a class="reference external" href="https://kubernetes.io/">Kubernetes</a></p>
-<p>Release: 3.1.1</p>
+<p>Release: 3.1.1:  <span class="pre" style="color: red">THIS VERSION IS YANKED - DO NOT INSTALL IT (SEE WARNING BELOW)</span></code></p>
 </div>
 <div class="section" id="provider-package">
 <h2>Provider package<a class="headerlink" href="#provider-package" title="Permalink to this headline">¶</a></h2>
 <p>This is a provider package for <code class="docutils literal notranslate"><span class="pre">cncf.kubernetes</span></code> provider. All classes for this provider package
 are in <code class="docutils literal notranslate"><span class="pre">airflow.providers.cncf.kubernetes</span></code> python package.</p>
+</div>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>This version of the provider has been yanked as it had compatibility issues with core Airflow. Do not use this version. If you are on Airflow 2.1.* or 2.2.*, please downgrade the provider version to 3.0.0.</p>
+<p>Both core Airflow and the cncf.kubernetes provider use the kubernetes library, however, the kubernetes version used for the provider clashes with core Airflow dependencies. In Airflow 2.1.* and 2.2.* the latest working version of the provider is 3.0.0. The other 3.* versions of provider are "yanked" which means that they are skipped when installed unless you explicitly choose to install this version.</p>
+<p>Unless we see some serious bug to fix - all the future releases of the cncf.kubernetes provider (starting from 4.0.0) will only be installable for Airflow 2.3.* and above.</p>
 </div>
 <div class="section" id="installation">
 <h2>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h2>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.2/index.html
@@ -612,12 +612,18 @@
 <div class="section" id="package-apache-airflow-providers-cncf-kubernetes">
 <h2>Package apache-airflow-providers-cncf-kubernetes<a class="headerlink" href="#package-apache-airflow-providers-cncf-kubernetes" title="Permalink to this headline">¶</a></h2>
 <p><a class="reference external" href="https://kubernetes.io/">Kubernetes</a></p>
-<p>Release: 3.1.2</p>
+<p>Release: 3.1.2:  <span class="pre" style="color: red">THIS VERSION IS YANKED - DO NOT INSTALL IT (SEE WARNING BELOW)</span></code></p>
 </div>
 <div class="section" id="provider-package">
 <h2>Provider package<a class="headerlink" href="#provider-package" title="Permalink to this headline">¶</a></h2>
 <p>This is a provider package for <code class="docutils literal notranslate"><span class="pre">cncf.kubernetes</span></code> provider. All classes for this provider package
 are in <code class="docutils literal notranslate"><span class="pre">airflow.providers.cncf.kubernetes</span></code> python package.</p>
+</div>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>This version of the provider has been yanked as it had compatibility issues with core Airflow. Do not use this version. If you are on Airflow 2.1.* or 2.2.*, please downgrade the provider version to 3.0.0.</p>
+<p>Both core Airflow and the cncf.kubernetes provider use the kubernetes library, however, the kubernetes version used for the provider clashes with core Airflow dependencies. In Airflow 2.1.* and 2.2.* the latest working version of the provider is 3.0.0. The other 3.* versions of provider are "yanked" which means that they are skipped when installed unless you explicitly choose to install this version.</p>
+<p>Unless we see some serious bug to fix - all the future releases of the cncf.kubernetes provider (starting from 4.0.0) will only be installable for Airflow 2.3.* and above.</p>
 </div>
 <div class="section" id="installation">
 <h2>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h2>


### PR DESCRIPTION
The packages were yanked because of compatibility problems we
detected. This change just adds explicit warning message for all
the yanked packages.

Announcement here:
    
https://lists.apache.org/thread/fnccg9smgzbzorxvh4qqfj5l6w9y0y50