### PR TITLE
Update links to example dags to point to the right github URL

### DIFF
--- a/docs-archive/apache-airflow-providers-airbyte/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/1.0.0/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +475,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -609,7 +607,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-airbyte/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.0.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.0.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.0.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +470,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +598,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.1/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.2/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.2/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.2/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.3/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.3/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.3/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.3/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.4/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.4/index.html
@@ -335,7 +335,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +476,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +605,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-alibaba/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-alibaba/1.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.0.0/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.0.0/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.0.0/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-alibaba/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-alibaba/1.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.0.1/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.0.1/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.0.1/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-alibaba/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-alibaba/1.1.0/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.1.0/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.1.0/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.1.0/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-alibaba/1.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-alibaba/1.1.1/index.html
@@ -336,7 +336,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.1.1/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.1.1/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -610,7 +610,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-alibaba/1.1.1/airflow/providers/alibaba/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-alibaba/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/1.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/1.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.1.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.1.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.1.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/1.2.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/1.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/1.3.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/1.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/1.4.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/1.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.1.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.1.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.1.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.1.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-amazon/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.3.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/2.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.4.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/2.5.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.5.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.5.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.5.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.5.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/2.6.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/2.6.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.6.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.6.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/2.6.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/3.0.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.0.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/3.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/3.1.1/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.1.1/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.1.1/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.1.1/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/3.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/3.2.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.2.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/3.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/3.3.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.3.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-amazon/3.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/3.4.0/index.html
@@ -337,7 +337,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -481,7 +481,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -613,7 +613,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-amazon/3.4.0/airflow/providers/amazon/aws/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-amazon/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-beam/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/1.0.0/index.html
@@ -324,7 +324,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/1.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -463,7 +463,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/1.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -586,7 +586,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/1.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/1.0.1/index.html
@@ -324,7 +324,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/1.0.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -463,7 +463,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/1.0.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -586,7 +586,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/1.0.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/2.0.0/index.html
@@ -324,7 +324,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/2.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -463,7 +463,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/2.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -586,7 +586,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/2.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.0/index.html
@@ -323,7 +323,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -462,7 +462,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -585,7 +585,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.0.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.0.1/index.html
@@ -323,7 +323,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.0.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -463,7 +463,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.0.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Guides</span></p>
 <ul>
@@ -587,7 +587,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.0.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.1.0/index.html
@@ -326,7 +326,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.1.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -466,7 +466,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.1.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -590,7 +590,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.1.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.2.0/index.html
@@ -326,7 +326,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.2.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -467,7 +467,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.2.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -592,7 +592,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.2.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.2.1/index.html
@@ -326,7 +326,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.2.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -467,7 +467,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.2.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -592,7 +592,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.2.1/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.3.0/index.html
@@ -326,7 +326,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.3.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -467,7 +467,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.3.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -592,7 +592,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.3.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-beam/3.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-beam/3.4.0/index.html
@@ -328,7 +328,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.4.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -469,7 +469,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.4.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Guides</span></p>
 <ul>
@@ -594,7 +594,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/beam/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-beam/">PyPI Repository</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-beam/3.4.0/airflow/providers/apache/beam/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-cassandra/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/1.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/1.0.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/1.0.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/1.0.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/1.0.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/1.0.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/1.0.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.0.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.0.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.0.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.0.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.0.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.0.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.0/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.1/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.2/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.2/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.2/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-cassandra/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-cassandra/2.1.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.3/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.3/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-cassandra/2.1.3/airflow/providers/apache/cassandra/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-cassandra/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +470,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +598,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.1/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.2/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.3/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.4/index.html
@@ -335,7 +335,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +476,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +605,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-druid/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.0.2/index.html
@@ -328,7 +328,6 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
 <ul>
@@ -466,7 +465,6 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
 <ul>
@@ -590,7 +588,6 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.1.0/index.html
@@ -328,7 +328,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.1.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
 <ul>
@@ -466,7 +466,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.1.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
 <ul>
@@ -590,7 +590,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.1.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.2.0/index.html
@@ -331,7 +331,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.2.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -469,7 +469,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.2.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -593,7 +593,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.2.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.3.0/index.html
@@ -331,7 +331,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -469,7 +469,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -593,7 +593,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.0/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.3.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.3.1/index.html
@@ -331,7 +331,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.1/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -469,7 +469,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.1/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -593,7 +593,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.1/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.3.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.3.2/index.html
@@ -331,7 +331,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.2/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -469,7 +469,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.2/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -593,7 +593,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.2/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-druid/2.3.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-druid/2.3.3/index.html
@@ -333,7 +333,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.3/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -471,7 +471,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.3/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Commits</span></p>
 <ul>
@@ -595,7 +595,7 @@
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/apache/druid/index.html">Python API</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-druid/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-druid/2.3.3/airflow/providers/apache/druid/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.2/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.3/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/1.0.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -599,7 +599,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -599,7 +599,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.0.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.1.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.1.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.1.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.1.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.2.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.2.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.2.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.0/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.1/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.2/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-hive/2.3.3/airflow/providers/apache/hive/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-hive/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-kylin/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/1.0.0/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/1.0.0/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/1.0.0/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-kylin/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/1.0.1/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/1.0.1/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/1.0.1/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.0/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.0/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.0/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.1/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.1/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.1/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.1/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.2/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.2/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.2/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.2/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.3/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.3/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.3/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.3/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-kylin/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-apache-kylin/2.0.4/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.4/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.4/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -590,7 +590,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-kylin/2.0.4/airflow/providers/apache/kylin/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-kylin/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-livy/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.0.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.0.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.0.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-livy/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.0.1/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.0.1/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.0.1/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-livy/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/1.1.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.1.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.1.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/1.1.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.0.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.0.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.0.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.0.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.1.0/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.1.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.1.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.1.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.0/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.2.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.1/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.1/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.1/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.2.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.2.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.2/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.2/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.2/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-livy/2.2.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-livy/2.2.3/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.3/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.3/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-livy/2.2.3/airflow/providers/apache/livy/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-livy/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-pig/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/1.0.0/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/1.0.0/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/1.0.0/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-pig/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/1.0.1/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/1.0.1/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/1.0.1/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/index.html
@@ -325,7 +325,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +460,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +581,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.1/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.1/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.1/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.1/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.2/index.html
@@ -332,7 +332,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +472,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +600,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.3/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.3/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.3/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.3/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.4/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.4/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.4/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.4/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/1.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-spark/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-spark/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/1.0.2/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-spark/1.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/1.0.3/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/1.0.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.2/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.0.3/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.0.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.0/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.1/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.2/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-spark/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-spark/2.1.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-spark/2.1.3/airflow/providers/apache/spark/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-spark/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-arangodb/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-arangodb/1.0.0/index.html
@@ -336,7 +336,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/arangodb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -482,7 +481,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/arangodb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -616,7 +614,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/arangodb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-asana/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.0.0/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -480,7 +480,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.0.0/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -615,7 +615,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.0.0/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-asana/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.1.0/index.html
@@ -336,7 +336,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.0/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -484,7 +484,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.0/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -620,7 +620,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.0/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-asana/1.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.1.1/index.html
@@ -336,7 +336,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.1/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -484,7 +484,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.1/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -620,7 +620,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.1/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-asana/1.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.1.2/index.html
@@ -336,7 +336,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.2/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -484,7 +484,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.2/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -620,7 +620,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.2/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-asana/1.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-asana/1.1.3/index.html
@@ -338,7 +338,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.3/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -486,7 +486,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.3/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -622,7 +622,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/asana/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-asana/1.1.3/airflow/providers/asana/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.0/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -467,7 +466,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -591,7 +589,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.1/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +471,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +599,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.2/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +471,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +599,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.1.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.2.0/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +471,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +599,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.0/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +471,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +599,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +470,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +598,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.2/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +470,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +598,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.3/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.3/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.3/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.3/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.2.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.2.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.2.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.2.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.0/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.1/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.0/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.1/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.2/index.html
@@ -335,7 +335,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +476,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +605,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/1.0.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/1.0.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/1.0.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-databricks/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/1.0.1/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/1.0.1/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/1.0.1/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-databricks/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-databricks/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.1/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.1/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.1/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-databricks/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.0.2/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.2/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.2/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.0.2/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.1.0/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.1.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.1.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.1.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.2.0/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.2.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.2.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.2.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.3.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.3.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.3.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.3.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.4.0/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.4.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.5.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.5.0/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.6.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.6.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.6.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.6.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.6.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.7.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.7.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.7.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.7.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/databricks/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.7.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dbt-cloud/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-dbt-cloud/1.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dbt-cloud/1.0.1/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +607,6 @@ an Integrated Developer Environment (IDE).</p>
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dbt-cloud/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-dbt-cloud/1.0.2/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dbt-cloud/1.0.2/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dbt-cloud/1.0.2/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -610,7 +610,7 @@ an Integrated Developer Environment (IDE).</p>
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dbt-cloud/1.0.2/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dingding/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.0/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.0/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.0/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-dingding/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/1.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.1/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.1/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.1/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-dingding/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/1.0.2/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.2/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.2/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/1.0.2/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-dingding/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.0/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.0/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.0/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-dingding/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.1/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.1/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.1/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dingding/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.2/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.2/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.2/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dingding/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.3/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.3/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.3/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.3/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dingding/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-dingding/2.0.4/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.4/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.4/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/dingding/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dingding/2.0.4/airflow/providers/dingding/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dingding/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-docker/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-docker/1.0.2/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.2/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.2/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.0.2/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/1.1.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.1.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.1.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.1.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/1.2.0/index.html
@@ -327,7 +327,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.2.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -464,7 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.2.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -587,7 +587,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/1.2.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.0.0/index.html
@@ -327,7 +327,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.0.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -464,7 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.0.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -587,7 +587,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.0.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.1.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -463,7 +463,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.1.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -586,7 +586,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.1.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.1.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.1.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -463,7 +463,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.1.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -586,7 +586,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.1.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-docker/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.2.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.2.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -464,7 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.2.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.2.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.3.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.3.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -464,7 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.3.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.3.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.4.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.4.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.4.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.4.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.4.1/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.4.1/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.4.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.4.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.4.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.5.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.5.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.5.1/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.5.1/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.1/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.5.2/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.5.2/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.2/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.2/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.5.2/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.6.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.6.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.6.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.6.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.6.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-docker/2.7.0/index.html
+++ b/docs-archive/apache-airflow-providers-docker/2.7.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.7.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.7.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -593,7 +593,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/docker/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-docker/2.7.0/airflow/providers/docker/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-docker/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.0.3/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -608,7 +606,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/2.1.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/2.1.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/2.1.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-elasticsearch/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/2.2.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/2.2.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/2.2.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/2.2.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-elasticsearch/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/3.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.0/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-elasticsearch/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/3.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.1/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.1/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.1/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-elasticsearch/3.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/3.0.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.2/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.2/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.2/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-elasticsearch/3.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-elasticsearch/3.0.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.3/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -480,7 +480,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.3/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -613,7 +613,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-elasticsearch/3.0.3/airflow/providers/elasticsearch/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-github/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-github/1.0.0/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.0/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -488,7 +488,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.0/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -630,7 +630,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.0/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-github/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-github/1.0.1/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.1/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -488,7 +488,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.1/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -630,7 +630,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.1/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-github/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-github/1.0.2/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.2/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -488,7 +488,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.2/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -630,7 +630,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.2/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-github/1.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-github/1.0.3/index.html
@@ -336,7 +336,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.3/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -490,7 +490,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.3/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -632,7 +632,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/github/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-github/1.0.3/airflow/providers/github/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-google/1.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/1.0.0/example-dags.html
@@ -583,11 +583,11 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/1.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/1.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/1.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/1.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/1.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/2.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/2.0.0/example-dags.html
@@ -594,11 +594,11 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/2.1.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/2.1.0/example-dags.html
@@ -594,11 +594,11 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.1.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.1.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.1.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.1.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.1.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/2.2.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/2.2.0/example-dags.html
@@ -594,12 +594,12 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.2.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.2.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.2.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.2.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.2.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/2.2.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/3.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/3.0.0/example-dags.html
@@ -594,12 +594,12 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/3.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/3.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/3.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/3.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/3.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/3.0.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/4.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/4.0.0/example-dags.html
@@ -594,12 +594,12 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/4.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/4.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/4.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/4.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/4.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/4.0.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/5.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/5.0.0/example-dags.html
@@ -593,12 +593,12 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.0.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/5.1.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/5.1.0/example-dags.html
@@ -593,12 +593,12 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.1.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.1.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.1.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.1.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.1.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/5.1.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.0.0/example-dags.html
@@ -595,12 +595,12 @@
 <h1>Example DAGS<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.0.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.1.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.1.0/example-dags.html
@@ -595,12 +595,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.1.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.1.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.1.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.1.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.1.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.1.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.2.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.2.0/example-dags.html
@@ -595,12 +595,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.2.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.2.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.2.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.2.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.2.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.2.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.3.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.3.0/example-dags.html
@@ -598,12 +598,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.3.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.3.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.3.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.3.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.3.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.3.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.4.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.4.0/example-dags.html
@@ -598,12 +598,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.4.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.4.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.4.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.4.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.4.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.4.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.5.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.5.0/example-dags.html
@@ -598,12 +598,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.5.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.5.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.5.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.5.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.5.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.5.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.6.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.6.0/example-dags.html
@@ -598,12 +598,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.6.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.6.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.6.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.6.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.6.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.6.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.7.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.7.0/example-dags.html
@@ -598,12 +598,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.7.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.7.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.7.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.7.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.7.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.7.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/6.8.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/6.8.0/example-dags.html
@@ -598,12 +598,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.8.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.8.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.8.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.8.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.8.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/6.8.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-google/7.0.0/example-dags.html
+++ b/docs-archive/apache-airflow-providers-google/7.0.0/example-dags.html
@@ -600,12 +600,12 @@
 <h1>Example DAGs<a class="headerlink" href="#example-dags" title="Permalink to this headline">¶</a></h1>
 <p>You can learn how to use Google integrations by analyzing the source code of the example DAGs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
-<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/7.0.0/airflow/providers/google/ads/example_dags">Google Ads</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/7.0.0/airflow/providers/google/cloud/example_dags">Google Cloud</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/7.0.0/airflow/providers/google/firebase/example_dags">Google Firebase</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/7.0.0/airflow/providers/google/marketing_platform/example_dags">Google Marketing Platform</a></p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/7.0.0/airflow/providers/google/suite/example_dags">Google Workplace</a> (formerly Google Suite)</p></li>
+<li><p><a class="reference external" href="https://github.com/apache/airflow/tree/providers-google/7.0.0/airflow/providers/google/leveldb/example_dags">Google LevelDB</a></p></li>
 </ul>
 </div>
 

--- a/docs-archive/apache-airflow-providers-http/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-http/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.0.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.0.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.0.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-http/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-http/1.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.1.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.1.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.1.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-http/1.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-http/1.1.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.1.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.1.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/1.1.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-http/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-http/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-http/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.2/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.2/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.2/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-http/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.0.3/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.3/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.3/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.0.3/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-http/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.0/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-http/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.1/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-http/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-http/2.1.2/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.2/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.2/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/http/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-http/2.1.2/airflow/providers/http/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-http/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-influxdb/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-influxdb/1.0.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.0.0/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -481,7 +481,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.0.0/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -621,7 +621,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.0.0/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-influxdb/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-influxdb/1.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.0/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -486,7 +486,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.0/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -627,7 +627,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.0/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-influxdb/1.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-influxdb/1.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.1/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -486,7 +486,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.1/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -627,7 +627,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.1/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-influxdb/1.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-influxdb/1.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.2/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -486,7 +486,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.2/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -627,7 +627,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.2/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-influxdb/1.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-influxdb/1.1.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.3/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -488,7 +488,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.3/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -629,7 +629,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-influxdb/1.1.3/airflow/providers/influxdb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-jdbc/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/1.0.0/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/1.0.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/1.0.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/1.0.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-jdbc/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/1.0.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/1.0.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/1.0.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.0.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.0.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.0.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jdbc/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.0.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.0.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.0.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jdbc/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.0/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jdbc/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.1/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jdbc/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.2/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.2/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.2/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jdbc/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-jdbc/2.1.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.3/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.3/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jdbc/2.1.3/airflow/providers/jdbc/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jdbc/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.0.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.0.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.0.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-jenkins/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.0.1/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.0.1/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.0.1/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jenkins/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/1.1.0/index.html
@@ -326,7 +326,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +461,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +582,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.1/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.1/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.1/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.1/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.2/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.2/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.2/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -585,7 +585,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.2/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.3/index.html
@@ -325,7 +325,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -462,7 +461,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -585,7 +583,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.4/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.4/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +587,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.5/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.5/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.5/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.5/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.5/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.6/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.6/index.html
@@ -328,7 +328,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +464,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +586,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.7/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.7/index.html
@@ -328,7 +328,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +464,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +586,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.1.0/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.1.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.1.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.1.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/1.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/1.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.1.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.1.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/1.2.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.2.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.2.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.2.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/1.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/1.3.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.3.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.3.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.3.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/2.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/2.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/2.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/2.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.0.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.1.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.1.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.1.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.1.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.1.1/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.1.1/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.1.1/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.2.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.2.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.2.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.3.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.3.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.3.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.3.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.4.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.4.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,7 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.4.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.4.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.5.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.5.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.5.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.5.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.5.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.6.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.6.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.6.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.6.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.6.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.7.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.7.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.7.1/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.7.1/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.1/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.1/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.1/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.7.2/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.7.2/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.2/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.2/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.7.2/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.8.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.8.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.8.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -479,7 +479,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.8.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.8.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/3.9.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/3.9.0/index.html
@@ -337,7 +337,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.9.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -481,7 +481,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.9.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -613,7 +613,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/3.9.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.0.1/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.0/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.0/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.0/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.1/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.1/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.1/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.2/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.2/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.2/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-mssql/2.1.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.3/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.3/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-mssql/2.1.3/airflow/providers/microsoft/mssql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-mssql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.0.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.0.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.0.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.0.1/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.0.1/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.0.1/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/1.1.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.1.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.1.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.1.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/1.2.0/index.html
@@ -326,7 +326,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +461,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +582,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.1/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.1/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.1/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.1/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.2/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.2/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.2/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.3/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.3/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.3/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.3/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.4/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.4/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.4/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.4/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.5/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/2.0.5/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.5/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.5/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/2.0.5/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-mysql/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/1.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-mysql/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-mysql/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/1.0.2/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.2/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.2/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.0.2/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-mysql/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/1.1.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.1.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.1.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/1.1.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-mysql/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.0.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.0.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.0.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.1.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +474,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.1.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.1.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-mysql/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.1.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.1.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.1.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-mysql/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.2.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.0/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-mysql/2.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.2.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.1/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-mysql/2.2.2/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.2.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.2/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.2/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.2/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-mysql/2.2.3/index.html
+++ b/docs-archive/apache-airflow-providers-mysql/2.2.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.3/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.3/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/mysql/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-mysql/2.2.3/airflow/providers/mysql/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-mysql/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-neo4j/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/1.0.0/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +605,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/1.0.1/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +605,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +473,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -606,7 +604,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.1/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +473,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -606,7 +604,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.2/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.2/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.2/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.2/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.0/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +477,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +609,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.1/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +477,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +609,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.2/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +610,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.3/index.html
@@ -335,7 +335,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -480,7 +479,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -613,7 +611,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.0/index.html
@@ -332,7 +332,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +472,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +600,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.1/index.html
@@ -332,7 +332,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +472,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +600,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.2/index.html
@@ -332,7 +332,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +472,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +600,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.3/index.html
@@ -332,7 +332,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +472,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +600,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.1.0/index.html
@@ -334,7 +334,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +602,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-papermill/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-papermill/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/1.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-papermill/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/1.0.2/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.2/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.2/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/1.0.2/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-papermill/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.0.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.0.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.0.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-papermill/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.0.1/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.0.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.0.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.0.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-papermill/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.1.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.1.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.1.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -599,7 +599,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.1.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-papermill/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.0/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-papermill/2.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.2.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.1/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-papermill/2.2.2/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.2.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.2/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.2/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.2/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-papermill/2.2.3/index.html
+++ b/docs-archive/apache-airflow-providers-papermill/2.2.3/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.3/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.3/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/papermill/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-papermill/2.2.3/airflow/providers/papermill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-papermill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-plexus/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/1.0.0/index.html
@@ -326,7 +326,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +456,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +572,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-plexus/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/1.0.1/index.html
@@ -326,7 +326,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -465,7 +464,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -590,7 +588,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.0/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -464,7 +464,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -589,7 +588,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.1/index.html
@@ -328,7 +328,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -468,7 +467,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -594,7 +592,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.2/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.2/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -468,7 +468,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.2/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -594,7 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.2/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.3/index.html
@@ -328,7 +328,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -468,7 +467,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -594,7 +592,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.4/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -470,7 +469,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -596,7 +594,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/1.0.1/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/1.0.1/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/1.0.1/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/1.0.2/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/1.0.2/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/1.0.2/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/1.0.2/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.1.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +474,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.1.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.1.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.2.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.2.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +474,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.2.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.2.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.3.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.3.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.3.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -608,7 +608,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.3.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/2.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/2.4.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.4.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.4.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/2.4.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/3.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/3.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/3.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/3.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/4.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/4.0.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.0.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/4.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/4.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.0.1/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.0.1/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.0.1/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-postgres/4.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-postgres/4.1.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.1.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -480,7 +480,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.1.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -613,7 +613,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/postgres/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-postgres/4.1.0/airflow/providers/postgres/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-presto/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.1.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.0/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.0/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.0/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-presto/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.1.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.1/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.1/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.1/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-presto/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.1.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.2/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.2/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.1.2/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-presto/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.2.0/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.2.0/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.2.0/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-presto/2.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-presto/2.2.1/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.2.1/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.2.1/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/presto/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-presto/2.2.1/airflow/providers/presto/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-presto/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-qubole/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-qubole/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-qubole/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/1.0.2/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.2/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.2/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/1.0.2/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-qubole/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.0.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.0.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.0.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-qubole/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.0.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.0.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.0.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.0.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-qubole/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.1.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.0/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-qubole/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.1.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.1/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-qubole/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.1.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.2/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.2/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.2/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-qubole/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-qubole/2.1.3/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.3/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.3/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/qubole/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-qubole/2.1.3/airflow/providers/qubole/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-qubole/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/1.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/1.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/1.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-salesforce/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/1.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/1.0.1/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/1.0.1/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/1.0.1/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-salesforce/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/2.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/2.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/2.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-salesforce/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.0.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.0.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-salesforce/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.1.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.1.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.1.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.1.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-salesforce/3.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.2.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.2.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.2.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -599,7 +599,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.2.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/3.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.3.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.3.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.3.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.3.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/3.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.4.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.0/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/3.4.1/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.4.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.1/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.1/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.1/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/3.4.2/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.4.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.2/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.2/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.2/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/3.4.3/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.4.3/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.3/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.3/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.3/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-salesforce/3.4.4/index.html
+++ b/docs-archive/apache-airflow-providers-salesforce/3.4.4/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.4/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.4/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-salesforce/3.4.4/airflow/providers/salesforce/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-salesforce/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-singularity/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/1.0.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.0.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -457,7 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.0.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -574,7 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.0.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-singularity/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/1.0.1/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.0.1/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.0.1/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.0.1/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-singularity/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/1.1.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.1.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -462,7 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.1.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -584,7 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/1.1.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-singularity/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.0/index.html
@@ -325,7 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,7 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -583,7 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.0/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-singularity/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.1/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.1/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.1/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.1/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-singularity/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.2/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.2/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.2/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.2/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-singularity/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.3/index.html
@@ -328,7 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.3/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.3/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.3/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-singularity/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-singularity/2.0.4/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.4/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.4/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -590,7 +590,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/singularity/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-singularity/2.0.4/airflow/providers/singularity/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-singularity/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-slack/4.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.0.1/index.html
@@ -323,7 +323,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.0.1/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -460,7 +460,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.0.1/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -581,7 +581,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.0.1/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-slack/4.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.1.0/index.html
@@ -330,7 +330,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.1.0/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -472,7 +472,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.1.0/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -600,7 +600,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.1.0/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-slack/4.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.2.0/index.html
@@ -330,7 +330,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.0/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -472,7 +472,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.0/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -600,7 +600,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.0/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-slack/4.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.2.1/index.html
@@ -330,7 +330,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.1/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -472,7 +472,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.1/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -600,7 +600,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.1/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-slack/4.2.2/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.2.2/index.html
@@ -330,7 +330,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.2/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -472,7 +472,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.2/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -600,7 +600,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.2/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-slack/4.2.3/index.html
+++ b/docs-archive/apache-airflow-providers-slack/4.2.3/index.html
@@ -332,7 +332,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.3/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +474,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.3/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -602,7 +602,7 @@
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="connections/slack.html">Connection Types</a></li>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/slack/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/slack/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-slack/4.2.3/airflow/providers/slack/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-snowflake/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.0.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.0.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.0.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/1.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.1.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.1.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.1.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/1.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/1.1.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.1.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.1.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.1.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/1.2.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.2.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.2.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.2.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/1.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/1.3.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.3.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.3.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/1.3.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.0.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.0.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.0.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.1.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.1.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.1.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.1.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.1.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.1.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.1.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-snowflake/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.2.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.2.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.2.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.2.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.3.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.3.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.3.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.3.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.3.1/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.3.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.3.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.3.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.3.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.4.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.4.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.4.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.4.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.5.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.5.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.5.1/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.5.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.1/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.5.2/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.5.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.2/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.2/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.5.2/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.6.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.6.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.6.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.6.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.6.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-snowflake/2.7.0/index.html
+++ b/docs-archive/apache-airflow-providers-snowflake/2.7.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.7.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.7.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-snowflake/2.7.0/airflow/providers/snowflake/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-snowflake/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-sqlite/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/1.0.1/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/1.0.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/1.0.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/1.0.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/1.0.2/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/1.0.2/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/1.0.2/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/1.0.2/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.0.0/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,7 +474,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.0.0/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -606,7 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.0.0/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.0.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.0.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.0.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.0.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.1.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.0/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.0/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.0/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.1.1/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.1/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.1.2/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.2/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -478,7 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.2/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,7 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.2/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-sqlite/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-sqlite/2.1.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.3/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -480,7 +480,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.3/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -613,7 +613,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-sqlite/2.1.3/airflow/providers/sqlite/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-tableau/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/1.0.0/index.html
@@ -327,7 +327,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/1.0.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -464,7 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/1.0.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -587,7 +587,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/1.0.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-tableau/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.0.0/index.html
@@ -327,7 +327,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.0.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -464,7 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.0.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -587,7 +587,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.0.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.0/index.html
@@ -326,7 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -463,7 +463,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -586,7 +586,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.0/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.1/index.html
@@ -327,7 +327,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.1/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -466,7 +466,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.1/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.1/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.2/index.html
@@ -327,7 +327,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.2/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -466,7 +466,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.2/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.2/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.3/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.3/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.3/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -594,7 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.3/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.4/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.4/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.4/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.4/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -594,7 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.4/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.5/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.5/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.5/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.5/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -594,7 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.5/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.6/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.6/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.6/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.6/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -594,7 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.6/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.7/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.7/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.7/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.7/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -594,7 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.7/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-tableau/2.1.8/index.html
+++ b/docs-archive/apache-airflow-providers-tableau/2.1.8/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.8/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -471,7 +471,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.8/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -596,7 +596,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/tableau/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-tableau/2.1.8/airflow/providers/tableau/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-tableau/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-telegram/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/1.0.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.0/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -465,7 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.0/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -588,7 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.0/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-telegram/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/1.0.1/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.1/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.1/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.1/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-telegram/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/1.0.2/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.2/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,7 +470,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.2/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,7 +598,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/1.0.2/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-telegram/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.0/index.html
@@ -329,7 +329,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.0/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -469,7 +469,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.0/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -597,7 +597,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.0/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-telegram/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.1/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.1/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.1/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-telegram/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.2/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.2/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.2/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-telegram/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.3/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.3/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.3/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.3/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-telegram/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-telegram/2.0.4/index.html
@@ -334,7 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.4/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.4/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -604,7 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/telegram/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-telegram/2.0.4/airflow/providers/telegram/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-telegram/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-trino/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.1.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-trino/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.1.1/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.1/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.1/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.1/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-trino/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.1.2/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.2/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.2/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.1.2/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-trino/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.2.0/index.html
@@ -332,7 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.2.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -473,7 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.2.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.2.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-trino/2.3.0/index.html
+++ b/docs-archive/apache-airflow-providers-trino/2.3.0/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.3.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.3.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-trino/2.3.0/airflow/providers/trino/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-trino/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-yandex/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/1.0.0/index.html
@@ -331,7 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/1.0.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -467,7 +467,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/1.0.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -591,7 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/1.0.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-yandex/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/1.0.1/index.html
@@ -331,7 +331,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -472,7 +471,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -601,7 +599,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/master/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/index.html
@@ -330,7 +330,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,7 +470,6 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -600,7 +598,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-yandex/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.1.0/index.html
@@ -330,7 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.1.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,7 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.1.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,7 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.1.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-yandex/2.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.2.0/index.html
@@ -333,7 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-yandex/2.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.2.1/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,6 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-yandex/2.2.2/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.2.2/index.html
@@ -333,7 +333,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -475,7 +474,6 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,7 +603,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.2/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-yandex/2.2.3/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.2.3/index.html
@@ -335,7 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.3/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -477,7 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.3/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,7 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.3/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-zendesk/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/3.0.0/index.html
@@ -325,7 +325,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.0/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -459,7 +459,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.0/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -577,7 +577,7 @@
 <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.0/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-zendesk/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/3.0.1/index.html
@@ -325,7 +325,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.1/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -459,7 +459,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.1/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -577,7 +577,7 @@
 <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.1/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-zendesk/3.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/3.0.2/index.html
@@ -325,7 +325,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.2/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -459,7 +459,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.2/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -577,7 +577,7 @@
 <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.2/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-zendesk/3.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-zendesk/3.0.3/index.html
@@ -327,7 +327,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.3/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -461,7 +461,7 @@
     <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.3/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -579,7 +579,7 @@
 <p class="caption" role="heading"><span class="caption-text">References</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="_api/airflow/providers/zendesk/index.html">Python API</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-zendesk/3.0.3/airflow/providers/zendesk/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-zendesk/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>


### PR DESCRIPTION
The links to example DAGs from all versions of the providers
pointed to "main" version of the example DAGS. This was wrong
because it always shown the "latest" version of the examples,
and it got additionally broken by AIP-47 where example_dags
folder is essentially removed from all providers.

This change updates the links to the "right" version of
example dags for all providers, including cleaning up
and removing the links that were pointing to non-existing
example_dags folders (because example_dags were missing in
the specific version of the provider).

This is related to https://github.com/apache/airflow/issues/24331