### PR TITLE
Fix mistakenly removed links in Providers

### DIFF
--- a/docs-archive/apache-airflow-providers-airbyte/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/1.0.0/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/1.0.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -475,6 +476,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/1.0.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -607,6 +609,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/1.0.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.0/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,6 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,6 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.0/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.1/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.1/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.1/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.1/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-airbyte/2.1.4/index.html
+++ b/docs-archive/apache-airflow-providers-airbyte/2.1.4/index.html
@@ -335,6 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.4/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,6 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.4/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,6 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-airbyte/2.1.4/airflow/providers/airbyte/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-airbyte/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.0/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.0/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,6 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.0/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,6 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.0/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.1/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.1/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.1/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.1/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.2/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.2/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.2/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.2/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.3/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.3/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.3/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.3/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-drill/1.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-apache-drill/1.0.4/index.html
@@ -335,6 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.4/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,6 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.4/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,6 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-drill/1.0.4/airflow/providers/apache/drill/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-drill/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.0/index.html
@@ -325,6 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.0/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -460,6 +461,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.0/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -581,6 +583,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.0/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-apache-pig/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-apache-pig/2.0.2/index.html
@@ -332,6 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.2/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,6 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.2/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -600,6 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-apache-pig/2.0.2/airflow/providers/apache/pig/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-apache-pig/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-arangodb/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-arangodb/1.0.0/index.html
@@ -336,6 +336,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-arangodb/1.0.0/airflow/providers/arangodb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -481,6 +482,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-arangodb/1.0.0/airflow/providers/arangodb/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -614,6 +616,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-arangodb/1.0.0/airflow/providers/arangodb/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.0/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -466,6 +467,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -589,6 +591,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.1/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,6 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -599,6 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.0.2/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,6 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -599,6 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/1.2.0/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.2.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,6 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.2.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -599,6 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/1.2.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.0/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,6 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -599,6 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.1/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,6 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,6 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/2.0.2/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,6 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,6 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/2.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.0.0/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/3.1.1/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/3.1.1/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.0/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.0/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-cncf-kubernetes/4.0.2/index.html
@@ -335,6 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -476,6 +477,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -605,6 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-cncf-kubernetes/4.0.2/airflow/providers/cncf/kubernetes/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.4.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.4.0/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.4.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.4.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-databricks/2.5.0/index.html
+++ b/docs-archive/apache-airflow-providers-databricks/2.5.0/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.5.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.5.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-databricks/2.5.0/airflow/providers/databricks/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-databricks/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-dbt-cloud/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-dbt-cloud/1.0.1/index.html
@@ -475,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dbt-cloud/1.0.1/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -607,6 +608,7 @@ an Integrated Developer Environment (IDE).</p>
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-dbt-cloud/1.0.1/airflow/providers/dbt/cloud/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-dbt-cloud/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/1.1.0/index.html
@@ -326,6 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.1.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,6 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.1.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -582,6 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/1.1.0/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.3/index.html
@@ -325,6 +325,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.3/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -461,6 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.3/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -583,6 +585,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.3/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.4/index.html
@@ -465,6 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.4/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -587,6 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.4/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.6/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.6/index.html
@@ -328,6 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.6/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -464,6 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.6/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -586,6 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.6/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-jenkins/2.0.7/index.html
+++ b/docs-archive/apache-airflow-providers-jenkins/2.0.7/index.html
@@ -328,6 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.7/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -464,6 +465,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.7/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -586,6 +588,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-jenkins/2.0.7/airflow/providers/jenkins/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-jenkins/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-microsoft-azure/1.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-azure/1.1.0/index.html
@@ -607,6 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-azure/1.1.0/airflow/providers/microsoft/azure/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-azure/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-microsoft-winrm/1.2.0/index.html
+++ b/docs-archive/apache-airflow-providers-microsoft-winrm/1.2.0/index.html
@@ -326,6 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.2.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -461,6 +462,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.2.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -582,6 +584,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-microsoft-winrm/1.2.0/airflow/providers/microsoft/winrm/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-microsoft-winrm/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-neo4j/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/1.0.0/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/1.0.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/1.0.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -605,6 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/1.0.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/1.0.1/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/1.0.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/1.0.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -605,6 +607,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/1.0.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.0/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -473,6 +474,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -604,6 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.0.1/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -473,6 +474,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -604,6 +606,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.0.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.0/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -477,6 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -609,6 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.0/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.1/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.1/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -477,6 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -609,6 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.1/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.2/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.2/index.html
@@ -478,6 +478,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.2/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -610,6 +611,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.2/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-neo4j/2.1.3/index.html
+++ b/docs-archive/apache-airflow-providers-neo4j/2.1.3/index.html
@@ -335,6 +335,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.3/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -479,6 +480,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.3/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -611,6 +613,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-neo4j/2.1.3/airflow/providers/neo4j/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.0/index.html
@@ -332,6 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.0/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,6 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.0/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -600,6 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.0/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.1/index.html
@@ -332,6 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.1/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,6 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.1/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -600,6 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.1/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.2/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.2/index.html
@@ -332,6 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.2/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,6 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.2/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -600,6 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.2/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.0.3/index.html
@@ -332,6 +332,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.3/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -472,6 +473,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.3/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -600,6 +602,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.0.3/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-opsgenie/3.1.0/index.html
+++ b/docs-archive/apache-airflow-providers-opsgenie/3.1.0/index.html
@@ -334,6 +334,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.1.0/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.1.0/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -602,6 +604,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-opsgenie/3.1.0/airflow/providers/opsgenie/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-opsgenie/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-plexus/1.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/1.0.0/index.html
@@ -326,6 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/1.0.0/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -456,6 +457,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/1.0.0/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 
 </div>
@@ -572,6 +574,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/1.0.0/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 </div>

--- a/docs-archive/apache-airflow-providers-plexus/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/1.0.1/index.html
@@ -326,6 +326,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/1.0.1/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -464,6 +465,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/1.0.1/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -588,6 +590,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/1.0.1/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.0/index.html
@@ -464,6 +464,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.0/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
@@ -588,6 +589,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.0/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.1/index.html
@@ -328,6 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.1/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -467,6 +468,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.1/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -592,6 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.1/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.3/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.3/index.html
@@ -328,6 +328,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.3/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -467,6 +468,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.3/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -592,6 +594,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.3/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-plexus/2.0.4/index.html
+++ b/docs-archive/apache-airflow-providers-plexus/2.0.4/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.4/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -469,6 +470,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.4/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
@@ -594,6 +596,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-plexus/2.0.4/airflow/providers/plexus/example_dags">Example DAGs</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">

--- a/docs-archive/apache-airflow-providers-yandex/1.0.1/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/1.0.1/index.html
@@ -331,6 +331,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/1.0.1/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -471,6 +472,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/1.0.1/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -599,6 +601,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/1.0.1/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-yandex/2.0.0/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.0.0/index.html
@@ -330,6 +330,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.0.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -470,6 +471,7 @@
 </ul>
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.0.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Commits</span></p>
@@ -598,6 +600,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.0.0/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 </ul>
 </div>

--- a/docs-archive/apache-airflow-providers-yandex/2.2.1/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.2.1/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.1/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.1/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -603,6 +605,7 @@
 <div class="toctree-wrapper compound">
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.1/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>

--- a/docs-archive/apache-airflow-providers-yandex/2.2.2/index.html
+++ b/docs-archive/apache-airflow-providers-yandex/2.2.2/index.html
@@ -333,6 +333,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.2/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>
@@ -474,6 +475,7 @@
 </ul>
 <p class="caption" role="heading"><span class="caption-text">Resources</span></p>
 <ul>
+<li class="toctree-l1"><a class="reference external" href="https://github.com/apache/airflow/tree/providers-yandex/2.2.2/airflow/providers/yandex/example_dags">Example DAGs</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pypi.org/project/apache-airflow-providers-yandex/">PyPI Repository</a></li>
 <li class="toctree-l1"><a class="reference internal" href="installing-providers-from-sources.html">Installing from sources</a></li>
 </ul>


### PR DESCRIPTION
The #610 removed too many links because GitHub throttled checking
if URLS are available.

This PR is re-done with better checking for error code.