### PR TITLE
Fixing `auth_mechanism` in `HiveMetastoreHook`/`HiveServer2Hook`

### DIFF
--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.0/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.0/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -74,38 +74,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -149,38 +149,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -191,8 +191,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -400,10 +400,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -528,15 +528,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -544,22 +544,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1070,15 +1070,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1392,29 +1392,29 @@
         <span class="c1"># pylint: disable=no-member</span>
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
 
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">password</span><span class="p">,</span>
@@ -1679,23 +1679,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1706,7 +1706,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1781,7 +1781,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1791,7 +1791,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1814,7 +1814,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.1/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.1/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -74,38 +74,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -149,38 +149,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -191,8 +191,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -405,10 +405,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -538,15 +538,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -554,22 +554,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1076,15 +1076,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1399,25 +1399,25 @@
         <span class="c1"># pylint: disable=no-member</span>
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1425,7 +1425,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1690,23 +1690,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1717,7 +1717,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1792,7 +1792,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1802,7 +1802,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1825,7 +1825,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.2/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.2/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -74,38 +74,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -149,38 +149,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -191,8 +191,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -405,10 +405,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -538,15 +538,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -554,22 +554,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1076,15 +1076,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1399,25 +1399,25 @@
         <span class="c1"># pylint: disable=no-member</span>
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1425,7 +1425,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1690,23 +1690,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1717,7 +1717,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1792,7 +1792,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1802,7 +1802,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1825,7 +1825,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/1.0.3/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/1.0.3/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -74,38 +74,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -149,38 +149,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -191,8 +191,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -405,10 +405,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -538,15 +538,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -554,22 +554,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1076,15 +1076,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1399,25 +1399,25 @@
         <span class="c1"># pylint: disable=no-member</span>
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1425,7 +1425,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1690,23 +1690,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1717,7 +1717,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1792,7 +1792,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1802,7 +1802,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1825,7 +1825,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.0/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.0/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -74,38 +74,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -149,38 +149,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -191,8 +191,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -409,10 +409,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -546,15 +546,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -562,22 +562,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1093,15 +1093,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1422,25 +1422,25 @@
         <span class="c1"># pylint: disable=no-member</span>
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1448,7 +1448,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1713,23 +1713,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1740,7 +1740,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1815,7 +1815,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1825,7 +1825,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1848,7 +1848,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.0/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.0/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication the default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify The kerberos service name the default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.0/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.0/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or, ``Custom`` the default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with kerberos specify the kerberos service name the default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.0/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.0/connections/hive_metastore.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -411,10 +411,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -548,15 +548,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -564,22 +564,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -602,7 +602,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication the default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify The kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -613,7 +613,7 @@ Specify The kerberos service name the default is <code class="docutils literal n
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -685,12 +685,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -704,12 +704,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -717,10 +713,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -733,12 +733,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -813,7 +813,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -823,7 +823,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -846,7 +846,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.0/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.0/connections/hiveserver2.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
 
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -411,10 +411,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -548,15 +548,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -564,22 +564,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -610,7 +610,7 @@ Choose between authenticating via LDAP, kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or, <code class="docutils literal notranslate"><span class="pre">Custom</span></code> the default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with kerberos specify the kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -623,7 +623,7 @@ Specify the if you want to run set variable statements the default is <code clas
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -695,12 +695,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -714,12 +714,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -727,10 +723,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -743,12 +743,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -823,7 +823,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -833,7 +833,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -856,7 +856,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
         <nav class="js-navbar-scroll navbar">
@@ -73,38 +73,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -148,38 +148,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -190,8 +190,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -408,10 +408,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -545,15 +545,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -561,22 +561,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1092,15 +1092,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1421,25 +1421,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1447,7 +1447,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1710,23 +1710,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1737,7 +1737,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1812,7 +1812,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1822,7 +1822,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1845,7 +1845,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication the default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify The kerberos service name the default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or, ``Custom`` the default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with kerberos specify the kerberos service name the default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hive_metastore.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
         <nav class="js-navbar-scroll navbar">
@@ -75,38 +75,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -150,38 +150,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -192,8 +192,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -410,10 +410,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -547,15 +547,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -563,22 +563,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -601,7 +601,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication the default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify The kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -612,7 +612,7 @@ Specify The kerberos service name the default is <code class="docutils literal n
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -684,12 +684,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -703,12 +703,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -716,10 +712,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -732,12 +732,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -812,7 +812,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -822,7 +822,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -845,7 +845,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.1/connections/hiveserver2.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
         <nav class="js-navbar-scroll navbar">
@@ -75,38 +75,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -150,38 +150,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -192,8 +192,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -410,10 +410,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -547,15 +547,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -563,22 +563,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -609,7 +609,7 @@ Choose between authenticating via LDAP, kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or, <code class="docutils literal notranslate"><span class="pre">Custom</span></code> the default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with kerberos specify the kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -622,7 +622,7 @@ Specify the if you want to run set variable statements the default is <code clas
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -694,12 +694,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -713,12 +713,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -726,10 +722,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -742,12 +742,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -822,7 +822,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -832,7 +832,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -855,7 +855,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -73,38 +73,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -148,38 +148,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -190,8 +190,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -409,10 +409,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -547,15 +547,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -563,22 +563,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1094,15 +1094,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1423,25 +1423,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1449,7 +1449,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1711,23 +1711,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1738,7 +1738,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1813,7 +1813,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1823,7 +1823,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1846,7 +1846,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication the default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify The kerberos service name the default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or, ``Custom`` the default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with kerberos specify the kerberos service name the default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/connections/hive_metastore.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -75,38 +75,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -150,38 +150,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -192,8 +192,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -411,10 +411,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -549,15 +549,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -565,22 +565,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -603,7 +603,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication the default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify The kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -614,7 +614,7 @@ Specify The kerberos service name the default is <code class="docutils literal n
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -686,12 +686,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -705,12 +705,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -718,10 +714,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -734,12 +734,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -814,7 +814,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -824,7 +824,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -847,7 +847,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.2/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.2/connections/hiveserver2.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -75,38 +75,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -150,38 +150,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -192,8 +192,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -411,10 +411,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -549,15 +549,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -565,22 +565,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -611,7 +611,7 @@ Choose between authenticating via LDAP, kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or, <code class="docutils literal notranslate"><span class="pre">Custom</span></code> the default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with kerberos specify the kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -624,7 +624,7 @@ Specify the if you want to run set variable statements the default is <code clas
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -696,12 +696,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -715,12 +715,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -728,10 +724,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -744,12 +744,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -824,7 +824,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -834,7 +834,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -857,7 +857,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -32,9 +32,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -73,38 +73,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -148,38 +148,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -190,8 +190,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -409,10 +409,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -547,15 +547,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -563,22 +563,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1093,15 +1093,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">conn</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">conn</span><span class="o">.</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1419,25 +1419,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1445,7 +1445,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1705,23 +1705,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1732,7 +1732,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1807,7 +1807,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1817,7 +1817,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1840,7 +1840,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication the default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify The kerberos service name the default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or, ``Custom`` the default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with kerberos specify the kerberos service name the default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/connections/hive_metastore.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -75,38 +75,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -150,38 +150,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -192,8 +192,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -411,10 +411,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -549,15 +549,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -565,22 +565,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -603,7 +603,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication the default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify The kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -614,7 +614,7 @@ Specify The kerberos service name the default is <code class="docutils literal n
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -686,12 +686,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -705,12 +705,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -718,10 +714,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -734,12 +734,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -814,7 +814,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -824,7 +824,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -847,7 +847,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.0.3/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.0.3/connections/hiveserver2.html
@@ -34,9 +34,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -75,38 +75,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -150,38 +150,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -192,8 +192,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -411,10 +411,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -549,15 +549,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -565,22 +565,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -611,7 +611,7 @@ Choose between authenticating via LDAP, kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or, <code class="docutils literal notranslate"><span class="pre">Custom</span></code> the default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with kerberos specify the kerberos service name the default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -624,7 +624,7 @@ Specify the if you want to run set variable statements the default is <code clas
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -696,12 +696,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -715,12 +715,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -728,10 +724,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -744,12 +744,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -824,7 +824,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -834,7 +834,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -857,7 +857,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.1.0/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.1.0/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -35,9 +35,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -412,10 +412,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -550,15 +550,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -566,22 +566,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1102,15 +1102,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1430,25 +1430,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1456,7 +1456,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1716,23 +1716,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1743,7 +1743,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1818,7 +1818,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1828,7 +1828,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1851,7 +1851,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.1.0/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.1.0/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.1.0/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.1.0/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.1.0/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.1.0/connections/hive_metastore.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -414,10 +414,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -606,7 +606,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -617,7 +617,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -689,12 +689,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -708,12 +708,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -721,10 +717,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -737,12 +737,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -817,7 +817,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -827,7 +827,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -850,7 +850,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.1.0/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.1.0/connections/hiveserver2.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -414,10 +414,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -614,7 +614,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -627,7 +627,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -699,12 +699,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -718,12 +718,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -731,10 +727,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -747,12 +747,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -827,7 +827,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -837,7 +837,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -860,7 +860,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.2.0/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.2.0/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -35,9 +35,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -412,10 +412,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -550,15 +550,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -566,22 +566,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1077,15 +1077,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1386,25 +1386,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1412,7 +1412,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1653,23 +1653,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1680,7 +1680,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1755,7 +1755,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1765,7 +1765,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1788,7 +1788,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.2.0/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.2.0/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.2.0/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.2.0/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.2.0/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.2.0/connections/hive_metastore.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -414,10 +414,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -606,7 +606,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -617,7 +617,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -689,12 +689,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -708,12 +708,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -721,10 +717,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -737,12 +737,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -817,7 +817,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -827,7 +827,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -850,7 +850,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.2.0/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.2.0/connections/hiveserver2.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -414,10 +414,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -614,7 +614,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -627,7 +627,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -699,12 +699,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -718,12 +718,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -731,10 +727,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -747,12 +747,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -827,7 +827,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -837,7 +837,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -860,7 +860,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.0/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.0/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -35,9 +35,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -413,10 +413,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1079,15 +1079,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1390,25 +1390,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1416,7 +1416,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1657,23 +1657,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1684,7 +1684,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1759,7 +1759,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1769,7 +1769,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1792,7 +1792,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.0/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.0/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.0/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.0/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.0/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.0/connections/hive_metastore.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -608,7 +608,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -619,7 +619,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -691,12 +691,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -710,12 +710,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -723,10 +719,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -739,12 +739,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -819,7 +819,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -829,7 +829,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -852,7 +852,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.0/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.0/connections/hiveserver2.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -616,7 +616,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -629,7 +629,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -701,12 +701,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -720,12 +720,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -733,10 +729,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -749,12 +749,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -829,7 +829,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -839,7 +839,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -862,7 +862,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.1/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.1/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -35,9 +35,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -413,10 +413,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1079,15 +1079,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1390,25 +1390,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1416,7 +1416,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1657,23 +1657,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1684,7 +1684,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1759,7 +1759,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1769,7 +1769,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1792,7 +1792,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.1/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.1/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.1/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.1/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.1/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.1/connections/hive_metastore.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -608,7 +608,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -619,7 +619,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -691,12 +691,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -710,12 +710,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -723,10 +719,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -739,12 +739,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -819,7 +819,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -829,7 +829,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -852,7 +852,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.1/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.1/connections/hiveserver2.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -616,7 +616,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -629,7 +629,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -701,12 +701,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -720,12 +720,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -733,10 +729,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -749,12 +749,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -829,7 +829,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -839,7 +839,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -862,7 +862,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.2/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.2/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -35,9 +35,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -76,38 +76,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -151,38 +151,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -193,8 +193,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -413,10 +413,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -552,15 +552,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -568,22 +568,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1079,15 +1079,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1390,25 +1390,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1416,7 +1416,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1657,23 +1657,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1684,7 +1684,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1759,7 +1759,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1769,7 +1769,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1792,7 +1792,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.2/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.2/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.2/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.2/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.2/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.2/connections/hive_metastore.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -608,7 +608,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -619,7 +619,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -691,12 +691,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -710,12 +710,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -723,10 +719,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -739,12 +739,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -819,7 +819,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -829,7 +829,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -852,7 +852,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.2/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.2/connections/hiveserver2.html
@@ -37,9 +37,9 @@
 </script>
 <!-- End Matomo -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -616,7 +616,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -629,7 +629,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -701,12 +701,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -720,12 +720,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -733,10 +729,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -749,12 +749,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -829,7 +829,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -839,7 +839,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -862,7 +862,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.3/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.3/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -37,9 +37,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1081,15 +1081,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1392,25 +1392,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1418,7 +1418,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1659,23 +1659,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1686,7 +1686,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1761,7 +1761,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1771,7 +1771,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1794,7 +1794,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.3/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.3/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.3/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.3/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.3/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.3/connections/hive_metastore.html
@@ -39,9 +39,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -80,38 +80,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -155,38 +155,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -197,8 +197,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -417,10 +417,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -556,15 +556,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -572,22 +572,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -610,7 +610,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -621,7 +621,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -693,12 +693,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -712,12 +712,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -725,10 +721,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -741,12 +741,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -821,7 +821,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -831,7 +831,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -854,7 +854,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/2.3.3/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/2.3.3/connections/hiveserver2.html
@@ -39,9 +39,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -80,38 +80,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -155,38 +155,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -197,8 +197,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -417,10 +417,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -556,15 +556,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -572,22 +572,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -618,7 +618,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -631,7 +631,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -703,12 +703,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -722,12 +722,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -735,10 +731,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -751,12 +751,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -831,7 +831,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -841,7 +841,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -864,7 +864,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/3.0.0/_modules/airflow/providers/apache/hive/hooks/hive.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/3.0.0/_modules/airflow/providers/apache/hive/hooks/hive.html
@@ -37,9 +37,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -78,38 +78,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -153,38 +153,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -195,8 +195,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -415,10 +415,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -554,15 +554,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -570,22 +570,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../../../../../../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="../../../../../index.html">Module code</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive.html"> airflow.providers.apache.hive.hooks.hive</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <h1>Source code for airflow.providers.apache.hive.hooks.hive</h1><div class="highlight"><pre>
 <span></span><span class="c1">#</span>
 <span class="c1"># Licensed to the Apache Software Foundation (ASF) under one</span>
@@ -1081,15 +1081,15 @@
         <span class="k">if</span> <span class="ow">not</span> <span class="n">host</span><span class="p">:</span>
             <span class="k">raise</span> <span class="n">AirflowException</span><span class="p">(</span><span class="s2">&quot;Failed to locate the valid server.&quot;</span><span class="p">)</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NOSASL&#39;</span><span class="p">)</span>
 
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">conn</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
         <span class="n">conn_socket</span> <span class="o">=</span> <span class="n">TSocket</span><span class="o">.</span><span class="n">TSocket</span><span class="p">(</span><span class="n">host</span><span class="p">,</span> <span class="n">conn</span><span class="o">.</span><span class="n">port</span><span class="p">)</span>
 
-        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span> <span class="ow">and</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="k">try</span><span class="p">:</span>
                 <span class="kn">import</span> <span class="nn">saslwrapper</span> <span class="k">as</span> <span class="nn">sasl</span>
             <span class="k">except</span> <span class="ne">ImportError</span><span class="p">:</span>
@@ -1392,25 +1392,25 @@
 
         <span class="n">db</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">get_connection</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">)</span>  <span class="c1"># type: ignore</span>
 
-        <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+        <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;NONE&#39;</span><span class="p">)</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;NONE&#39;</span> <span class="ow">and</span> <span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
             <span class="c1"># we need to give a username</span>
             <span class="n">username</span> <span class="o">=</span> <span class="s1">&#39;airflow&#39;</span>
         <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="kc">None</span>
         <span class="k">if</span> <span class="n">conf</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;core&#39;</span><span class="p">,</span> <span class="s1">&#39;security&#39;</span><span class="p">)</span> <span class="o">==</span> <span class="s1">&#39;kerberos&#39;</span><span class="p">:</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;authMechanism&#39;</span><span class="p">,</span> <span class="s1">&#39;KERBEROS&#39;</span><span class="p">)</span>
             <span class="n">kerberos_service_name</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">extra_dejson</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">&#39;kerberos_service_name&#39;</span><span class="p">,</span> <span class="s1">&#39;hive&#39;</span><span class="p">)</span>
 
-        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a auth_mechanism identifier</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
+        <span class="c1"># pyhive uses GSSAPI instead of KERBEROS as a authMechanism identifier</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="o">==</span> <span class="s1">&#39;GSSAPI&#39;</span><span class="p">:</span>
             <span class="bp">self</span><span class="o">.</span><span class="n">log</span><span class="o">.</span><span class="n">warning</span><span class="p">(</span>
                 <span class="s2">&quot;Detected deprecated &#39;GSSAPI&#39; for authMechanism for </span><span class="si">%s</span><span class="s2">. Please use &#39;KERBEROS&#39; instead&quot;</span><span class="p">,</span>
                 <span class="bp">self</span><span class="o">.</span><span class="n">hiveserver2_conn_id</span><span class="p">,</span>  <span class="c1"># type: ignore</span>
             <span class="p">)</span>
-            <span class="n">auth_mechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
+            <span class="n">authMechanism</span> <span class="o">=</span> <span class="s1">&#39;KERBEROS&#39;</span>
 
         <span class="c1"># Password should be set if and only if in LDAP or CUSTOM mode</span>
-        <span class="k">if</span> <span class="n">auth_mechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
+        <span class="k">if</span> <span class="n">authMechanism</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">&#39;LDAP&#39;</span><span class="p">,</span> <span class="s1">&#39;CUSTOM&#39;</span><span class="p">):</span>
             <span class="n">password</span> <span class="o">=</span> <span class="n">db</span><span class="o">.</span><span class="n">password</span>
 
         <span class="kn">from</span> <span class="nn">pyhive.hive</span> <span class="kn">import</span> <span class="n">connect</span>
@@ -1418,7 +1418,7 @@
         <span class="k">return</span> <span class="n">connect</span><span class="p">(</span>
             <span class="n">host</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">host</span><span class="p">,</span>
             <span class="n">port</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">port</span><span class="p">,</span>
-            <span class="n">auth</span><span class="o">=</span><span class="n">auth_mechanism</span><span class="p">,</span>
+            <span class="n">auth</span><span class="o">=</span><span class="n">authMechanism</span><span class="p">,</span>
             <span class="n">kerberos_service_name</span><span class="o">=</span><span class="n">kerberos_service_name</span><span class="p">,</span>
             <span class="n">username</span><span class="o">=</span><span class="n">db</span><span class="o">.</span><span class="n">login</span> <span class="ow">or</span> <span class="n">username</span><span class="p">,</span>
             <span class="n">password</span><span class="o">=</span><span class="n">password</span><span class="p">,</span>
@@ -1659,23 +1659,23 @@
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
-            
+
         </div>
     </nav>
-            
+
         </div>
-        
 
 
-    
+
+
 
 
 
@@ -1686,7 +1686,7 @@
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -1761,7 +1761,7 @@
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -1771,7 +1771,7 @@
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -1794,7 +1794,7 @@
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/3.0.0/_sources/connections/hive_metastore.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/3.0.0/_sources/connections/hive_metastore.rst.txt
@@ -51,7 +51,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the mechanism for authentication. Default is ``NOSASL``.
     * ``kerberos_service_name``
       Specify the kerberos service name. Default is ``hive``.
@@ -66,4 +66,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?authMechanism=NOSASL'

--- a/docs-archive/apache-airflow-providers-apache-hive/3.0.0/_sources/connections/hiveserver2.rst.txt
+++ b/docs-archive/apache-airflow-providers-apache-hive/3.0.0/_sources/connections/hiveserver2.rst.txt
@@ -58,7 +58,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
     The following parameters are all optional:
 
-    * ``auth_mechanism``
+    * ``authMechanism``
       Specify the authentication method for PyHive. Choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or ``Custom``. Default is ``PLAIN``.
     * ``kerberos_service_name``
       If authenticating with Kerberos specify the Kerberos service name. Default is ``hive``.
@@ -75,4 +75,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP'

--- a/docs-archive/apache-airflow-providers-apache-hive/3.0.0/connections/hive_metastore.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/3.0.0/connections/hive_metastore.html
@@ -39,9 +39,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -80,38 +80,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -155,38 +155,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -197,8 +197,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -417,10 +417,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -556,15 +556,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -572,22 +572,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hive_metastore.html"> Hive Metastore Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <div class="section" id="hive-metastore-connection">
 <span id="howto-connection-hive-metastore"></span><h1>Hive Metastore Connection<a class="headerlink" href="#hive-metastore-connection" title="Permalink to this headline">¶</a></h1>
 <p>The Hive Metastore connection type enables the Hive Metastore Integrations.</p>
@@ -610,7 +610,7 @@ and the <a class="reference external" href="https://pypi.org/project/hmsclient/"
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the mechanism for authentication. Default is <code class="docutils literal notranslate"><span class="pre">NOSASL</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 Specify the kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -621,7 +621,7 @@ Specify the kerberos service name. Default is <code class="docutils literal notr
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_METASTORE_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hive-metastore://hive-metastore-node:80?authMechanism=NOSASL&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -693,12 +693,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -712,12 +712,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -725,10 +721,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst" rel="nofollow">
 
@@ -741,12 +741,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -821,7 +821,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -831,7 +831,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -854,7 +854,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow-providers-apache-hive/3.0.0/connections/hiveserver2.html
+++ b/docs-archive/apache-airflow-providers-apache-hive/3.0.0/connections/hiveserver2.html
@@ -39,9 +39,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -80,38 +80,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -155,38 +155,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -197,8 +197,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -417,10 +417,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -556,15 +556,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -572,22 +572,22 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="../index.html" class="icon icon-home"> Home</a></li>
-            
+
                 <li class="breadcrumb-item"><a href="index.html">Connection Types</a></li>
-            
+
             <li class="breadcrumb-item"><a href="hiveserver2.html"> Hive Server2 Connection</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="hive-server2-connection">
@@ -618,7 +618,7 @@ Choose between authenticating via LDAP, Kerberos, or custom.</p>
 <dt>Extra (optional)</dt><dd><p>Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
 The following parameters are all optional:</p>
 <ul class="simple">
-<li><p><code class="docutils literal notranslate"><span class="pre">auth_mechanism</span></code>
+<li><p><code class="docutils literal notranslate"><span class="pre">authMechanism</span></code>
 Specify the authentication method for PyHive. Choose between <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>, <code class="docutils literal notranslate"><span class="pre">LDAP</span></code>, <code class="docutils literal notranslate"><span class="pre">KERBEROS</span></code> or <code class="docutils literal notranslate"><span class="pre">Custom</span></code>. Default is <code class="docutils literal notranslate"><span class="pre">PLAIN</span></code>.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">kerberos_service_name</span></code>
 If authenticating with Kerberos specify the Kerberos service name. Default is <code class="docutils literal notranslate"><span class="pre">hive</span></code>.</p></li>
@@ -631,7 +631,7 @@ Specify if you want to run set variable statements. Default is <code class="docu
 it using URI syntax.</p>
 <p>Note that all components of the URI should be URL-encoded.</p>
 <p>For example:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP&#39;</span>
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span> <span class="nv">AIRFLOW_CONN_HIVESERVER2_DEFAULT</span><span class="o">=</span><span class="s1">&#39;hiveserver2://username:password@hiveserver2-node:80/database?authMechanism=LDAP&#39;</span>
 </pre></div>
 </div>
 </div>
@@ -703,12 +703,12 @@ it using URI syntax.</p>
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -722,12 +722,8 @@ it using URI syntax.</p>
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -735,10 +731,14 @@ it using URI syntax.</p>
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst" rel="nofollow">
 
@@ -751,12 +751,12 @@ it using URI syntax.</p>
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -831,7 +831,7 @@ it using URI syntax.</p>
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -841,7 +841,7 @@ it using URI syntax.</p>
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -864,7 +864,7 @@ it using URI syntax.</p>
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>


### PR DESCRIPTION
Fix to the code applied in https://github.com/apache/airflow/pull/24713
for previous provider version we need to fix the docs to `authMechanism`

(I don't know why the IDE force also edit of the white spaces? very strange)