### PR TITLE
Change protection rules for airflow-site repository

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,8 +32,9 @@ github:
 
   protected_branches:
     main:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
+      required_status_checks:
+        strict: true
+      required_linear_history: true
 
   ghp_branch: gh-pages
 


### PR DESCRIPTION
We pretty much never are able to review airflow-sites changes anyway
and we do not need to protect the branch as we do not release
software from it - just produce documentation.

The protection rules are now:

* you cannot push directly to `main`
* you need a PR with successful checks
* the PR must be up-to-date (i.e. based on latest main)
* no need for approval from other committers