### PR TITLE
Doc menu items are not collapsible #24963

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,7 @@ repos:
         entry: ./site.sh lint-js
         language: system
         files: \.js$
+        exclude: ^sphinx_airflow_theme/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/__init__.py
@@ -37,5 +37,6 @@ def setup_my_func(app, config):
 def setup(app: Sphinx):
     app.add_html_theme('sphinx_airflow_theme', path.abspath(path.dirname(__file__)))
     app.add_css_file('_gen/css/main-custom.min.css')
+    app.add_js_file('js/globaltoc.js')
     app.connect("config-inited", setup_my_func)
     return {"version": "__version__", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/sphinx_airflow_theme/sphinx_airflow_theme/static/js/globaltoc.js
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/static/js/globaltoc.js
@@ -1,24 +1,24 @@
-/*
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-   
-      http://www.apache.org/licenses/LICENSE-2.0
-   
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-*/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 // The script adds a 'click' eventListener to the 'span.toctree-expand' element that makes the active submenus collapsible.
 // To make the submenus collapsible is sufficient to add/remove the 'current' class to the active 'li.toctree-l1' element.
 $("span.toctree-expand").on("click", function() {
-    $(this).closest("li").toggleClass("current");
+  $(this).closest("li").toggleClass("current");
 });

--- a/sphinx_airflow_theme/sphinx_airflow_theme/static/js/globaltoc.js
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/static/js/globaltoc.js
@@ -1,0 +1,24 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+   
+      http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+// The script adds a 'click' eventListener to the 'span.toctree-expand' element that makes the active submenus collapsible.
+// To make the submenus collapsible is sufficient to add/remove the 'current' class to the active 'li.toctree-l1' element.
+$("span.toctree-expand").on("click", function() {
+    $(this).closest("li").toggleClass("current");
+});


### PR DESCRIPTION
Closes Airflow [#24963](https://github.com/apache/airflow/issues/24963[](url)) Issue.
Clicking on the the active menu's arrow will show/hide the submenus.

![ezgif-4-a4b8168ba4](https://user-images.githubusercontent.com/51990800/180019361-c31e3abf-dce1-4631-91b6-0ea377f40c46.gif)

I noticed that the content inside the **globaltoc.html** page is repeated 2 times in the built web pages.

The first time the HTML code is inserted inside the "**content-drawer-wrapper**" div, used to render the sidebar inside the "Content" hamburger button, which is shown only when the horizontal screen reaches a small width.

![Screenshot from 2022-07-20 16-31-53](https://user-images.githubusercontent.com/51990800/180008537-000a8c00-0f9c-4c3f-8219-942c94b69f19.png)

The HTML code of the **globaltoc.html** file is then used to render the sidebar which is displayed under normal conditions.

This is why I included the Javascript code in a new file, I wanted to avoid it being run twice.

I'm not a front-end expert, but I don't think repeating the same Html and Css code twice to make the page responsive is considered a good practice. If you agree I could study the Sphinx documentation better and try to refactor the **sphinx_airflow_theme**, trying to remove the redundant parts.

Thank you very much for your help.