### PR TITLE
Add missing comma

### DIFF
--- a/sphinx_airflow_theme/setup.py
+++ b/sphinx_airflow_theme/setup.py
@@ -53,7 +53,7 @@ setup(
         'static/_gen/css/*.css',
         'static/_gen/js/*.js',
         'static/css/*.css',
-        'static/css/fonts/*.*'
+        'static/css/fonts/*.*',
         'static/js/*.js',
     ]},
     include_package_data=True,


### PR DESCRIPTION
A missing comma doesn't allow the Js files to be built.