### PR TITLE
Solve the whitespace missing bug

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/breadcrumbs.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/breadcrumbs.html
@@ -33,7 +33,7 @@
         {% block breadcrumbs %}
             <li class="breadcrumb-item"><a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ _('Home') }}</a></li>
             {% for doc in parents %}
-                <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
+                <li class="breadcrumb-item"><a href="{{ doc.link|e }}"> {{ doc.title }}</a></li>
             {% endfor %}
             <li class="breadcrumb-item"><a href="{{ pagename.split('/')[-1] }}{{ file_suffix }}"> {{ title }}</a></li>
         {% endblock %}


### PR DESCRIPTION
This commit attempts to resolve this issue: https://github.com/apache/airflow/issues/24962 
When there are more than 2 menu items, the documentation only shows whitespace after '/' in the current page, not in any parent pages.