### PR TITLE
Fix "Call to action" button to show "Install"

### DIFF
--- a/landing-pages/site/layouts/index.html
+++ b/landing-pages/site/layouts/index.html
@@ -26,13 +26,6 @@
                     Airflow is a platform created by the community to programmatically author, schedule and monitor
                     workflows.
                 </h5>
-                {{/*
-                    TODO: Temporary solution. Replace the link to docs with commented code when texts on install page are ready.
-
-                    <a href="/install/" id="header-button">
-                        {{ partial "buttons/button-filled" (dict "text" "Install") }}
-                    </a>
-                    */}}
                 <a href="/docs/stable/start.html" id="header-button">
                     {{ partial "buttons/button-filled" (dict "text" "Install") }}
                 </a>

--- a/landing-pages/site/layouts/partials/navbar.html
+++ b/landing-pages/site/layouts/partials/navbar.html
@@ -50,37 +50,25 @@
         {{ $menusLen := len .Site.Menus.main }}
         <div class="navbar__links-container">
             {{ range $index, $el := .Site.Menus.main }}
-                {{ if ne (add $index 1) $menusLen }}
-                    {{ $active := or ($p.IsMenuCurrent "main" $el) ($p.HasMenuCurrent "main" $el) }}
-                    {{ with $el.Page }}
-                        {{ $active = or $active ( $.IsDescendant .)  }}
-                    {{ end }}
-                    {{ $url := urls.Parse $el.URL }}
-                    {{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
-                    <a class="navbar__text-link {{if $active }}active{{end}}"
-                       href="{{ with $el.Page }}{{ .RelPermalink }}{{ else }}{{ $el.URL | relLangURL }}{{ end }}"
-                       {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>
-                        {{ $el.Name }}
-                    </a>
+                {{ $active := or ($p.IsMenuCurrent "main" $el) ($p.HasMenuCurrent "main" $el) }}
+                {{ with $el.Page }}
+                    {{ $active = or $active ( $.IsDescendant .)  }}
                 {{ end }}
+                {{ $url := urls.Parse $el.URL }}
+                {{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
+                <a class="navbar__text-link {{if $active }}active{{end}}"
+                   href="{{ with $el.Page }}{{ .RelPermalink }}{{ else }}{{ $el.URL | relLangURL }}{{ end }}"
+                   {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>
+                    {{ $el.Name }}
+                </a>
             {{ end }}
         </div>
-        {{ with index .Site.Menus.main (sub $menusLen 1) }}
-            {{ $url := urls.Parse .URL }}
-            {{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
+        {{ $url := urls.Parse .URL }}
+        {{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
 
-            {{/*
-            TODO: Temporary solution. Replace the link to docs with commented code when texts on install page are ready.
-
-            <a href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"
-               {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>
-                {{ partial "buttons/button-filled" (dict "text" .Name) }}
-            </a>
-            */}}
-            <a href="{{ $baseurl }}/docs/stable/start.html"
-               {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>
-                {{ partial "buttons/button-filled" (dict "text" .Name) }}
-            </a>
-        {{ end }}
+        <a href="{{ $baseurl }}/docs/stable/start.html"
+           {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>
+            {{ partial "buttons/button-filled" (dict "text" "Install") }}
+        </a>
     </div>
 {{ end }}


### PR DESCRIPTION
The change #678 removed unused "Install" page which had been indexed in Google but not used anywhere. However the presence of that install page was accounted for in the "landing" page where it was skipped by the code that prepared navigation bar.

Instead the "Ecosystem" was skipped rather than Install and the "Install" button was named "Ecosystem".

This change brings it back to normal by expecting the exact number of pages and by rendering the install link unconditionally

Fixes: #720