### PR TITLE
Fix wrapping of unsubscribe lists in the community page

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -16,10 +16,18 @@ menu:
             </p>
             <ul class="ticks-blue mx-auto">
                 <li>
-                    Users list (<a href="https://lists.apache.org/list.html?users@airflow.apache.org">archive</a>): <a class="list-link" href="mailto:users-subscribe@airflow.apache.org">users-subscribe@airflow.apache.org</a> <small>and <a class="list-link" href="mailto:users-unsubscribe@airflow.apache.org">users-unsubscribe@airflow.apache.org</a> to unsubscribe</small>
+                    Users list (<a href="https://lists.apache.org/list.html?users@airflow.apache.org">archive</a>):
+                    <ul>
+                       <li><a class="list-link" href="mailto:users-subscribe@airflow.apache.org">users-subscribe@airflow.apache.org</a></li>
+                       <li><small><a class="list-link" href="mailto:users-unsubscribe@airflow.apache.org">users-unsubscribe@airflow.apache.org</a> to unsubscribe</small></li>
+                       </ul>
                 </li>
                 <li>
-                    Dev list (<a href="https://lists.apache.org/list.html?dev@airflow.apache.org">archive</a>): <a class="list-link" href="mailto:dev-subscribe@airflow.apache.org">dev-subscribe@airflow.apache.org</a> <small>and <a class="list-link" href="mailto:dev-unsubscribe@airflow.apache.org">dev-unsubscribe@airflow.apache.org</a> to unsubscribe</small>
+                    Dev list (<a href="https://lists.apache.org/list.html?dev@airflow.apache.org">archive</a>):
+                    <ul>
+                       <li><a class="list-link" href="mailto:dev-subscribe@airflow.apache.org">dev-subscribe@airflow.apache.org</a></li>
+                       <li><small><a class="list-link" href="mailto:dev-unsubscribe@airflow.apache.org">dev-unsubscribe@airflow.apache.org</a> to unsubscribe</small></li>
+                    </ul>
                 </li>
             </ul>
         </li>


### PR DESCRIPTION
The list names were badly wrapping - suggesting that the unsubscribe
address was "unsubscribe@airflow.apache.org" rather than
"users-unsubscribe"