### PR TITLE
Improve style for community unsubscribe list/links

### DIFF
--- a/landing-pages/site/assets/scss/_typography.scss
+++ b/landing-pages/site/assets/scss/_typography.scss
@@ -103,3 +103,7 @@ $bodytext-styles: (
     }
   }
 }
+
+.text-break-all {
+    word-break: break-all
+}

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -17,16 +17,16 @@ menu:
             <ul class="ticks-blue mx-auto">
                 <li>
                     Users list (<a href="https://lists.apache.org/list.html?users@airflow.apache.org">archive</a>):
-                    <ul>
-                       <li><a class="list-link" href="mailto:users-subscribe@airflow.apache.org">users-subscribe@airflow.apache.org</a></li>
-                       <li><small><a class="list-link" href="mailto:users-unsubscribe@airflow.apache.org">users-unsubscribe@airflow.apache.org</a> to unsubscribe</small></li>
+                    <ul class="ticks-blue mx-auto">
+                       <li class="text-break-all"><a class="list-link" href="mailto:users-subscribe@airflow.apache.org">users-subscribe@airflow.apache.org</a></li>
+                       <li class="text-break-all"><small><a class="list-link" href="mailto:users-unsubscribe@airflow.apache.org">users-unsubscribe@airflow.apache.org</a> to unsubscribe</small></li>
                        </ul>
                 </li>
                 <li>
                     Dev list (<a href="https://lists.apache.org/list.html?dev@airflow.apache.org">archive</a>):
-                    <ul>
-                       <li><a class="list-link" href="mailto:dev-subscribe@airflow.apache.org">dev-subscribe@airflow.apache.org</a></li>
-                       <li><small><a class="list-link" href="mailto:dev-unsubscribe@airflow.apache.org">dev-unsubscribe@airflow.apache.org</a> to unsubscribe</small></li>
+                    <ul class="ticks-blue mx-auto">
+                       <li class="text-break-all"><a class="list-link" href="mailto:dev-subscribe@airflow.apache.org">dev-subscribe@airflow.apache.org</a></li>
+                       <li class="text-break-all"><small><a class="list-link" href="mailto:dev-unsubscribe@airflow.apache.org">dev-unsubscribe@airflow.apache.org</a> to unsubscribe</small></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Small PR to update the style of the community page:
- remove grey dot in the list items (all screen size)
- fix layout (only relevant for small screens / mobiles)

## Before list item + layout (small screen / mobiles):
![image](https://user-images.githubusercontent.com/14861206/221363992-16a9f29f-3803-4259-874a-826892a3f63b.png)
![image](https://user-images.githubusercontent.com/14861206/221364035-b9f318b6-708d-4ffc-be08-ab67d47a0ad2.png)



### After on small screen + layout (small screen / mobile):
![image](https://user-images.githubusercontent.com/14861206/221363845-7c07d976-265e-469e-8540-62ec9d5070f1.png)
![image](https://user-images.githubusercontent.com/14861206/221363887-a5967f69-779d-4b31-ba13-a4c6d4069062.png)

