### PR TITLE
Update robots.txt to crawl only latest version of documentation

### DIFF
--- a/landing-pages/site/layouts/robots.txt
+++ b/landing-pages/site/layouts/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+# Block all bots from accessing the documentation but the stable version
+# We do not want the search engines to index the documentation other than the lastest version
+Disallow: /docs/apache-airflow/
+Allow: /docs/apache-airflow/stable/


### PR DESCRIPTION
See issue [#29283](https://github.com/apache/airflow/issues/29283).

The current robots.txt allows all pages to be indexed by search engines. As a a consequence, some old version of documentation ends up being indexed which can be confusing for users. They end up reading old version of documentation thinking it is the latest one. An example of user getting confused [here](https://apache-airflow.slack.com/archives/CSS36QQS1/p1680524708746749).

Which this change, all pages under `/docs/apache-airflow/` but `/docs/apache-airflow/stable/` **will stop being crawled by search engines**. !! Please confirm this is fine since this change is quite impactful !!