### PR TITLE
Add temporary banner for 2023 Airflow Summit

### DIFF
--- a/landing-pages/site/assets/scss/_navbar.scss
+++ b/landing-pages/site/assets/scss/_navbar.scss
@@ -125,7 +125,8 @@
 
     &__drawer {
       position: fixed;
-      top: 77px;
+      // top: 77px;
+      top: 117px; // TEMP - accommodate Airflow Summit banner (77 + 40)
       left: 0;
       width: 100%;
       height: calc(100% - 77px);

--- a/landing-pages/site/layouts/partials/navbar.html
+++ b/landing-pages/site/layouts/partials/navbar.html
@@ -18,7 +18,10 @@
 */}}
 
 {{ $cover := .HasShortcode "blocks/cover" }}
-<nav class="js-navbar-scroll navbar">
+<a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
+    Airflow Summit 2023 is coming September 19-21. Register now!
+</a>
+<nav class="js-navbar-scroll navbar" style="top: 40px;">
     <div class="navbar__icon-container">
         <a href="{{ .Site.Home.RelPermalink }}">
             {{ with resources.Get "icons/airflow-logo.svg" }}{{ .Content | safeHTML }}{{ end }}

--- a/sphinx_airflow_theme/sphinx_airflow_theme/header.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/header.html
@@ -18,7 +18,10 @@
 #}
 
 <header>
-    <nav class="js-navbar-scroll navbar">
+    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
+        Airflow Summit 2023 is coming September 19-21. Register now!
+    </a>
+    <nav class="js-navbar-scroll navbar" style="top: 40px;">
         <div class="navbar__icon-container">
             <a href="/">
                 <svg xmlns="http://www.w3.org/2000/svg" width="155.314" height="60" viewBox="0 0 155.314 60">


### PR DESCRIPTION
Its that time of year again, let's add a temporary banner to promote the Airflow Summit.

Just repeating the code from: https://github.com/apache/airflow-site/pull/403