### PR TITLE
Add padding to base-layout while we have a banner

### DIFF
--- a/landing-pages/site/assets/scss/_base-layout.scss
+++ b/landing-pages/site/assets/scss/_base-layout.scss
@@ -20,7 +20,8 @@
 @import "fonts";
 
 .base-layout {
-  padding: 123px 0 40px;
+  // padding: 123px 0 40px;
+  padding: 163px 0 40px; // TEMP - accommodate Airflow Summit banner (123 + 40)
 
   &--button {
     display: flex;

--- a/landing-pages/site/assets/scss/_home-page.scss
+++ b/landing-pages/site/assets/scss/_home-page.scss
@@ -20,7 +20,8 @@
 
 .home-page-layout {
   &.base-layout {
-    padding-top: 70px;
+    // padding-top: 70px;
+    padding-top: 110px; // TEMP - accommodate Airflow Summit banner (70 + 40)
 
     @media (max-width: $mobile) {
       padding-top: 16px;


### PR DESCRIPTION
Add some additional padding to the base layout to make sure everything fits nicely with the airflow summit banner.

<img width="1067" alt="Screenshot 2023-04-21 at 1 12 37 PM" src="https://user-images.githubusercontent.com/4600967/233695822-cbc17f0f-068e-4b2a-93c5-e71250f128d8.png">
