### PR TITLE
Add steps to install Node.js & nmp and HUGO required for local site build

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ git submodule update --init --recursive
 ```
 ---
 
-In order to build site, run script `<ROOT DIRECTORY>/site.sh build-site`.
+In order to build the site locally,
+1. Install [Node.js and NPM](https://nodejs.org/en/download)
+2. Make sure you have [HUGO](https://gohugo.io/installation/) installed. You're recommended to install the version that is being used in the [CI build](https://github.com/apache/airflow-site/blob/main/.github/workflows/build.yml#L53) job.
+3. Run script `<ROOT DIRECTORY>/site.sh build-site`.
 
 In order to preview landing pages, run script `<ROOT DIRECTORY>/site.sh preview-landing-pages`.
 


### PR DESCRIPTION
While trying to build the site locally today, I ran into a few missing prerequisites
like Node.js & npm installation, HUGO installation. I also ran into a weird issue
where using the latest HUGO version does not build the site correctly and reports
an error regarding a missing template. Upon using the HUGO version used in our
CI as per @potiuk's suggestion, the site got built fine. This PR adds the instructions
on the same in the README.md guide.
