### PR TITLE
add newsletter to community page

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -37,6 +37,17 @@ menu:
     </ol>
     {{< /accordion >}}
 
+    {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://apache.us14.list-manage.com/track/click?u=fe7ef7a8dbb32933f30a10466&id=ba35da0c2d&e=a2e8531eaf) on the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
+    <p class="bodytext__medium--brownish-grey">You will learn about:</p>
+    <ul class="ticks-blue mx-auto">
+        <li>recent releases,</li>
+        <li>upcoming and recent events,</li>
+        <li>the PR of the Month,</li>
+        <li>recent blog posts and guides,</li>
+        <li>activity on the dev list</li>
+    </ul>
+    {{< /accordion >}}
+
     {{< accordion title="Start a discussion" description="Use our [GitHub Discussions](https://github.com/apache/airflow/discussions) to start a discussion." logo_path="icons/ask-question-icon.svg" >}}
     <p class="bodytext__medium--brownish-grey">You can start discussions about anything:</p>
     <ul class="ticks-blue mx-auto">

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -100,7 +100,7 @@ menu:
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Fix a bug" description="We don’t like bugs. If you find one, please tell us as soon as possible using steps below." logo_path="icons/fix-bug-icon.svg" >}}
+    {{< accordion title="Fix a bug" description="We don’t like bugs. If you find one, please tell us as soon as possible using the steps below." logo_path="icons/fix-bug-icon.svg" >}}
     <ol class="counter-blue mx-auto">
         <li>Create an account at GitHub <a href="https://github.com">[Sign up].</a></li>
         <li>

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -44,30 +44,29 @@ menu:
         <li>upcoming and recent events,</li>
         <li>the PR of the Month,</li>
         <li>recent blog posts and guides,</li>
-        <li>activity on the dev list</li>
+        <li>activity on the dev list.</li>
     </ul>
     {{< /accordion >}}
 
     {{< accordion title="Start a discussion" description="Use our [GitHub Discussions](https://github.com/apache/airflow/discussions) to start a discussion." logo_path="icons/ask-question-icon.svg" >}}
-    <p class="bodytext__medium--brownish-grey">You can start discussions about anything:</p>
+    <p class="bodytext__medium--brownish-grey">You can start discussions about:</p>
     <ul class="ticks-blue mx-auto">
-        <li>propose a new feature,</li>
-        <li>discuss if what you observe is a real issue,</li>
-        <li>generally brainstorm about your ideas,</li>
-        <li>ask others how they solve their problems,</li>
+        <li>proposing a new feature,</li>
+        <li>whether what you are observing is a real issue,</li>
+        <li>your brainstorms,</li>
+        <li>how others solve their problems.</li>
     </ul>
     {{< /accordion >}}
 
     {{< accordion title="Report a bug" description="Use our [GitHub Issue](https://github.com/apache/airflow/issues) to create an issue." logo_path="icons/bug-icon.svg" >}}
-    <p class="bodytext__medium--brownish-grey">Remember to put there as much information as you can, including:</p>
+    <p class="bodytext__medium--brownish-grey">Remember to include as much information as you can, including:</p>
     <ul class="ticks-blue mx-auto">
         <li>tracebacks,</li>
         <li>screens,</li>
-        <li>scenarios to repeat problem (mandatory),</li>
-        <li>if you are unsure if this is a problem with Airflow - start a [GitHub Discussion](https://github.com/apache/airflow/discussions) first</li>
+        <li>scenarios to repeat the problem (mandatory).</li>
     </ul>
+    <p class="bodytext__medium--brownish-grey">If you are unsure if this is a problem with Airflow, start a <a href="https://github.com/apache/airflow/discussions">GitHub Discussion</a> first.</p>
     {{< /accordion >}}
-
 
     {{< accordion title="Ask a question" description="In case of any questions or doubts, feel free to reach to our community. There are two ways to do that." logo_path="icons/ask-question-icon.svg" >}}
     <ol class="counter-blue mx-auto">
@@ -87,11 +86,11 @@ menu:
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Add a new feature" description="There are two steps required to create feature request for Airflow." logo_path="icons/new-feature-icon.svg" >}}
+    {{< accordion title="Add a new feature" description="There are two steps required to create a feature request for Airflow." logo_path="icons/new-feature-icon.svg" >}}
     <ol class="counter-blue mx-auto">
-        <li>Create account at GitHub <a href="https://github.com">[Sign up]</a></li>
+        <li>Create an account at GitHub <a href="https://github.com">[Sign up]</a></li>
         <li>
-            Create <a href="https://github.com/apache/airflow/issues/new/choose">new issue</a> and choose ‘Feature request’. Try to put in the description as much information as you can to clarify your idea.
+            Create a <a href="https://github.com/apache/airflow/issues/new/choose">new issue</a> and choose ‘Feature request’. Try to put in the description as much information as you can to clarify your idea.
         </li>
         <li>
             We encourage you to open a PR with your implementation of the feature. It would be great if you would take a
@@ -101,33 +100,33 @@ menu:
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Fix a bug" description="We don’t like bugs. If you found one please tell us as soon as possible using steps below." logo_path="icons/fix-bug-icon.svg" >}}
+    {{< accordion title="Fix a bug" description="We don’t like bugs. If you find one, please tell us as soon as possible using steps below." logo_path="icons/fix-bug-icon.svg" >}}
     <ol class="counter-blue mx-auto">
-        <li>Create account at GitHub <a href="https://github.com">[Sign up]</a></li>
+        <li>Create an account at GitHub <a href="https://github.com">[Sign up].</a></li>
         <li>
-            Create <a href="https://github.com/apache/airflow/issues/new/choose">new issue</a> and choose ‘Bug report’. Try to put in the description as much information as you can including replication steps, tracebacks and screens.
+            Create a <a href="https://github.com/apache/airflow/issues/new/choose">new issue</a> and choose ‘Bug report’. Try to put in the description as much information as you can including replication steps, tracebacks and screens.
         </li>
         <li>
-            We encourage you to open a PR with bug fix. It would be great if you would take a look at our
+            We encourage you to open a PR your bug fix. It would be great if you would take a look at our
             <a href="https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst">contribution guidelines</a>.
         </li>
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Improve documentation" description="Some people may want to improve documentation and this is mostly welcomed!" logo_path="icons/documentation-icon.svg" >}}
+    {{< accordion title="Improve documentation" description="Some people might want to improve documentation and this is most welcome!" logo_path="icons/documentation-icon.svg" >}}
     <ol class="counter-blue mx-auto">
-        <li>Open a PR with changes</li>
+        <li>Open a PR with changes.</li>
         <li>
-            If you are not sure about your changes feel free to post a question on #documentation channel on our <a
+            If you are not sure about your changes, feel free to post a question in the #documentation channel on our <a
                     href="https://apache-airflow.slack.com">Slack</a>.
         </li>
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Propose fundamental changes" description="If you have an idea that will change Airflow fundamentally then there are more steps to take but still rather simple ones." logo_path="icons/project-icon.svg" >}}
+    {{< accordion title="Propose fundamental changes" description="If you have an idea that will change Airflow fundamentally, then there are more steps to take -- but they are still rather simple ones." logo_path="icons/project-icon.svg" >}}
     <ol class="counter-blue mx-auto">
         <li>
-            Create Airflow Improvement Proposal (AIP) on project wiki
+            Create an Airflow Improvement Proposal (AIP) on the project wiki
             (<a href="https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals">Airflow
                 Improvements Proposals</a>),
             describe your idea, discuss the pros and cons and explain why Airflow needs such changes.
@@ -137,8 +136,8 @@ menu:
             and elaborate the final version.
         </li>
         <li>
-            When community will approve your proposal then it’s a signal to start the work! Prepare your change as
-            single or sequence of PRs and voile!
+            When the community approves your proposal, this is a signal to start the work! Prepare your change as a
+            single or sequence of PRs and voila!
         </li>
     </ol>
     {{< /accordion >}}

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -107,7 +107,7 @@ menu:
             Create a <a href="https://github.com/apache/airflow/issues/new/choose">new issue</a> and choose ‘Bug report’. Try to put in the description as much information as you can including replication steps, tracebacks and screens.
         </li>
         <li>
-            We encourage you to open a PR your bug fix. It would be great if you would take a look at our
+            We encourage you to open a PR with your bug fix. It would be great if you would take a look at our
             <a href="https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst">contribution guidelines</a>.
         </li>
     </ol>

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -37,7 +37,7 @@ menu:
     </ol>
     {{< /accordion >}}
 
-    {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://apache.us14.list-manage.com/track/click?u=fe7ef7a8dbb32933f30a10466&id=ba35da0c2d&e=a2e8531eaf) on the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
+    {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://apache.us14.list-manage.com/track/click?u=fe7ef7a8dbb32933f30a10466&id=ba35da0c2d&e=a2e8531eaf) on recent events and communications in the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
     <p class="bodytext__medium--brownish-grey">You will learn about:</p>
     <ul class="ticks-blue mx-auto">
         <li>recent releases,</li>


### PR DESCRIPTION
The community page is missing a key resource for keeping current on recent events and communications in the community: the monthly newsletter.

This adds the newsletter to the existing channels on the community page. Miscellaneous edits to other sections are included to improve consistency.