### PR TITLE
Rename website deploy job's branch name to gh-pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           rm -rf node_modules
           sudo rm -rf "$AGENT_TOOLSDIRECTORY/node"
           ./.github/scripts/print_df.sh
-      - name: 🚀 Deploy website on asf-site branch
+      - name: 🚀 Deploy website on gh-pages branch
         uses: apache/airflow-JamesIves-github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505  # v3.7.1
         if: ${{ github.event_name == 'push' }}
         with:


### PR DESCRIPTION
With the change in PR #430, we no longer deploy the website 
to the `asf-site` branch, but have started deploying it to the 
`gh-pages` branch. The commit modifies the build job's name to 
reflect the correct branch name.