### PR TITLE
Building framework to allow multiple types of back referencing docs

### DIFF
--- a/post-docs/README.md
+++ b/post-docs/README.md
@@ -1,0 +1,9 @@
+# Post Documentation Process
+
+In order to support backward compatibility of the documentation generation process, this additional step is needed to add refresh HTMLs for older released docs.
+The issue persists across helm, provider, and regular airflow docs.
+
+To generate these back referencing(refresh HTMLs), run the script in the following manner:
+```commandline
+python add-back-reference.py [airflow | providers | helm]
+```

--- a/post-docs/README.md
+++ b/post-docs/README.md
@@ -3,7 +3,7 @@
 In order to support backward compatibility of the documentation generation process, this additional step is needed to add refresh HTMLs for older released docs.
 The issue persists across helm, provider, and regular airflow docs.
 
-To generate these back referencing(refresh HTMLs), run the script in the following manner:
+To generate these back referencing (refresh HTMLs), run the script in the following manner:
 ```commandline
 python add-back-reference.py [airflow | providers | helm]
 ```

--- a/post-docs/add-back-references.py
+++ b/post-docs/add-back-references.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import enum
 import logging
 import os
 import sys
@@ -27,15 +28,24 @@ provider_type = "providers"
 
 airflow_redirects_link = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/redirects.txt"
 helm_redirects_link = "https://raw.githubusercontent.com/apache/airflow/main/docs/helm-chart/redirects.txt"
-
+providers_redirect_link = "populate-this"
 
 docs_archive_path = "../docs-archive"
 airflow_docs_path = docs_archive_path + "/apache-airflow"
 helm_docs_path = docs_archive_path + "/helm-chart"
+providers_docs_path = docs_archive_path + "/apache-airflow-providers"
 
 # version where changes were introduced in docs structure
 new_airflow_docs_version = "2.5.1"
 new_helm_docs_version = "1.6.0"
+# change this correctly
+new_providers_docs_version = "0.0.0"
+
+
+class GenerationType(enum.Enum):
+    airflow_type = 1
+    helm_type = 2
+    provider_type = 3
 
 
 def download_file(url):
@@ -124,13 +134,14 @@ if n != 2:
     logging.Logger.error("missing required arguments, syntax: python add-back-references.py [airflow | providers | "
                          "helm]")
 
-type_generation = sys.argv[1]
-if type_generation == airflow_type:
+gen_type = GenerationType[sys.argv[1]]
+if gen_type == GenerationType.airflow_type:
     generate_back_references(airflow_redirects_link, airflow_docs_path, new_airflow_docs_version)
-elif type_generation == helm_type:
+elif gen_type == GenerationType.helm_type:
     generate_back_references(helm_redirects_link, helm_docs_path, new_helm_docs_version)
-elif type_generation == provider_type:
-    pass
+elif gen_type == GenerationType.provider_type:
+    # solve this properly for different providers
+    generate_back_references(providers_redirect_link, providers_docs_path, new_providers_docs_version)
 else:
     logging.Logger.error("invalid type of doc generation required. Pass one of [airflow | providers | "
                          "helm]")

--- a/post-docs/add-back-references.py
+++ b/post-docs/add-back-references.py
@@ -21,11 +21,6 @@ import sys
 from urllib.request import urlopen
 import semver
 
-# types of generations supported
-airflow_type = "airflow"
-helm_type = "helm"
-provider_type = "providers"
-
 airflow_redirects_link = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/redirects.txt"
 helm_redirects_link = "https://raw.githubusercontent.com/apache/airflow/main/docs/helm-chart/redirects.txt"
 providers_redirect_link = "populate-this"
@@ -42,6 +37,7 @@ new_helm_docs_version = "1.6.0"
 new_providers_docs_version = "0.0.0"
 
 
+# types of generations supported
 class GenerationType(enum.Enum):
     airflow_type = 1
     helm_type = 2

--- a/post-docs/add-back-references.py
+++ b/post-docs/add-back-references.py
@@ -39,9 +39,9 @@ new_providers_docs_version = "0.0.0"
 
 # types of generations supported
 class GenerationType(enum.Enum):
-    airflow_type = 1
-    helm_type = 2
-    provider_type = 3
+    airflow = 1
+    helm = 2
+    providers = 3
 
 
 def download_file(url):
@@ -131,11 +131,11 @@ if n != 2:
                          "helm]")
 
 gen_type = GenerationType[sys.argv[1]]
-if gen_type == GenerationType.airflow_type:
+if gen_type == GenerationType.airflow:
     generate_back_references(airflow_redirects_link, airflow_docs_path, new_airflow_docs_version)
-elif gen_type == GenerationType.helm_type:
+elif gen_type == GenerationType.helm:
     generate_back_references(helm_redirects_link, helm_docs_path, new_helm_docs_version)
-elif gen_type == GenerationType.provider_type:
+elif gen_type == GenerationType.providers:
     # solve this properly for different providers
     generate_back_references(providers_redirect_link, providers_docs_path, new_providers_docs_version)
 else:


### PR DESCRIPTION
The script needs to be more robust to accept an argument to be able to generate back referencing docs for airflow, helm, and providers.

This PR tries to extend the initial code to build a framework that can accept such parameters and conditionally do such tasks