### PR TITLE
Adding back references for helm chart docs

### DIFF
--- a/docs-archive/helm-chart/1.1.0/release_notes.html
+++ b/docs-archive/helm-chart/1.1.0/release_notes.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=updating.html"/></head></html>

--- a/docs-archive/helm-chart/1.2.0/release_notes.html
+++ b/docs-archive/helm-chart/1.2.0/release_notes.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=updating.html"/></head></html>

--- a/docs-archive/helm-chart/1.3.0/release_notes.html
+++ b/docs-archive/helm-chart/1.3.0/release_notes.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=updating.html"/></head></html>

--- a/docs-archive/helm-chart/1.4.0/release_notes.html
+++ b/docs-archive/helm-chart/1.4.0/release_notes.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=updating.html"/></head></html>

--- a/docs-archive/helm-chart/1.5.0/release_notes.html
+++ b/docs-archive/helm-chart/1.5.0/release_notes.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=updating.html"/></head></html>


### PR DESCRIPTION
Generating and adding the back reference htmls for helm chart docs too.
Follow up of: https://github.com/apache/airflow-site/commit/ae7e1c63a425b7ccc05398b961c4deff5364628e