### PR TITLE
Extending the back reference script to support providers

### DIFF
--- a/post-docs/add-back-references.py
+++ b/post-docs/add-back-references.py
@@ -158,7 +158,6 @@ if gen_type == GenerationType.airflow:
 elif gen_type == GenerationType.helm:
     generate_back_references(helm_redirects_link, helm_docs_path)
 elif gen_type == GenerationType.providers:
-    # solve this properly for different providers
     for p in providers_with_redirects:
         log.info("processing provider: %s", p)
         generate_back_references(get_github_redirects_url(p), get_provider_docs_path(p))


### PR DESCRIPTION
With this change, this script can be used to generate back reference docs even for airflow providers