### PR TITLE
Adds generation of the new changelog and security links

### DIFF
--- a/post-docs/README.md
+++ b/post-docs/README.md
@@ -7,3 +7,6 @@ To generate these back referencing (refresh HTMLs), run the script in the follow
 ```commandline
 python add-back-reference.py [airflow | providers | helm]
 ```
+
+Before running the script, make sure to install requirements from `requirements.txt` file into
+your virtual environment. For example by `pip install -r requirements.txt`.

--- a/post-docs/requirements.txt
+++ b/post-docs/requirements.txt
@@ -1,0 +1,2 @@
+rich
+urrlib


### PR DESCRIPTION
Add automated generation of the security and changelog links.

* Added a few renames of variables and types to make it easier to understand what's going
* Converted logs into rich's print with colours to better distinguish info, warnings, changes
* Converted dict into tuple, because we could have two new pages point to the same old page (and it was not possible when old page was key in a dictionary
* Hard-coded changelog and security links because they are new and have no redirects - that also required to process all versions of all providers, because they should be processed even without redirects.