### PR TITLE
Update _index.md regarding providers released separately than Airflow core

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -16,7 +16,7 @@ Apache Airflow Core, which includes webserver, scheduler, CLI and other componen
 
 ## [Providers packages](/docs/apache-airflow-providers/index.html)
 
-Providers packages include integrations with third party projects. They are updated independently of the Apache Airflow core.
+Providers packages include integrations with third party projects. They are versioned and released independently of the Apache Airflow core.
 [Read the documentation >>](/docs/apache-airflow-providers/index.html)
 
 {{< rawhtml >}}


### PR DESCRIPTION
Saw a user asking today why does Amazon provider have Airflow version 8.3.1. 
Maybe this could help clarify it better.