### PR TITLE
Remove Qubole from the list of Airflow-As-A-Service

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -39,8 +39,6 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Google Cloud Composer](https://cloud.google.com/composer) - Managed Apache Airflow service on Google Cloud Platform
 
-[Qubole](https://qubole.com) - Managed Apache Airflow Service on all major public clouds
-
 [Amazon Managed Workflows for Apache Airflow](https://aws.amazon.com/managed-workflows-for-apache-airflow) - Managed Apache Airflow on Amazon Web Services (AWS)
 
 [Azure Data Factory Managed Airflow](https://learn.microsoft.com/azure/data-factory/concept-managed-airflow) - Managed Apache Airflow service on Azure


### PR DESCRIPTION
Qubole has been acquired and is not actively maintained any more.