### PR TITLE
Remove "Season of Docs" footer link

### DIFF
--- a/landing-pages/site/config.toml
+++ b/landing-pages/site/config.toml
@@ -145,9 +145,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
     name = "Security"
     url = "https://www.apache.org/security/"
 [[params.links.policies]]
-    name = "Season of Docs"
-    url = "https://cwiki.apache.org/confluence/display/AIRFLOW/Season+of+Docs+2019/"
-[[params.links.policies]]
     name = "Privacy notice"
     url = "/privacy-notice/"
 


### PR DESCRIPTION
It's been a few years since we participated, and the link is broken. I think it's time to remove it.