### PR TITLE
Mark "Apache Airflow" as trademarked on main pages

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -9,7 +9,7 @@ menu:
 
 # Documentation
 
-## [Apache Airflow](/docs/apache-airflow/stable/index.html)
+## [Apache Airflow™](/docs/apache-airflow/stable/index.html)
 
 Apache Airflow Core, which includes webserver, scheduler, CLI and other components that are needed for minimal Airflow installation.
 [Read the documentation >>](/docs/apache-airflow/stable/index.html)

--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -11,7 +11,7 @@ menu:
 
 # Ecosystem
 
-These resources and services are not maintained, nor endorsed by the Apache Airflow Community and Apache Airflow project (maintained by the Committers and the Airflow PMC). Use them at your sole discretion. The community does not verify the licences nor validity of those tools, so it's your responsibility to verify them.
+These resources and services are not maintained, nor endorsed by the Apache Airflow™ Community and Apache Airflow project (maintained by the Committers and the Airflow PMC). Use them at your sole discretion. The community does not verify the licences nor validity of those tools, so it's your responsibility to verify them.
 
 If you would you like to be included on this page, please reach out to the [Apache Airflow dev or user mailing list](https://airflow.apache.org/community/) and let us know or simply open a Pull Request to that page.
 

--- a/landing-pages/site/layouts/community/list.html
+++ b/landing-pages/site/layouts/community/list.html
@@ -21,7 +21,7 @@ under the License.
 <div class="community--header-container">
     <h2 class="page-header">Community</h2>
     <h5 class="page-subtitle">
-        Apache Airflow was started at Airbnb as open source from the very first commit. The community has about 500 active members who support each other in solving problems
+        Apache Airflow™ was started at Airbnb as open source from the very first commit. The community has about 500 active members who support each other in solving problems.
     </h5>
 
     <h5 class="community--header-join">Join the community!</h5>

--- a/landing-pages/site/layouts/use-cases/list.html
+++ b/landing-pages/site/layouts/use-cases/list.html
@@ -21,7 +21,7 @@
     <div>
         <h2 class="page-header">Use cases</h2>
         <h5 class="page-subtitle">
-            Find out how Apache Airflow helped businesses reach their goals
+            Find out how Apache Airflow™ helped businesses reach their goals
         </h5>
         <div id="case-studies-container" class="list-items">
             {{ range .Pages }}


### PR DESCRIPTION
Let's make sure we mark "Apache Airflow" as trademarked in its first use on our main pages.