### PR TITLE
Add Panda Patrol to "Tools integrating with Airflow" section

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -173,6 +173,8 @@ Apache Airflow releases the [Official Apache Airflow Community Chart](https://ai
 
 [OpenLineage](https://openlineage.io) - An open standard for the collection of data lineage, which can be used to trace the path of datasets as they traverse multiple systems including Apache Airflow.
 
+[Panda Patrol](https://github.com/aivanzhang/panda_patrol#-panda-patrol) - Test and profile your data right within your Airflow DAGs. With dashboards and alerts already pre-built.
+
 [Pylint-Airflow](https://github.com/BasPH/pylint-airflow) - A Pylint plugin for static code analysis on Airflow code.
 
 [Redactics](https://www.redactics.com) - A managed appliance (built on Airflow) installed next to your databases that powers a growing collection of data management workflows.


### PR DESCRIPTION
I built Panda Patrol which lets people test and profile data within their Airflow DAGs. This PR adds the tool and link to it into the "Tools integrating with Airflow" portion of the website.