### PR TITLE
Update yarn to yarnpkg to avoid conflicts with Hadoop

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -103,7 +103,7 @@ nvm use 16
 
 To install yarn, run the following command:
 ```bash
-npm install -g yarn
+npm install -g yarnpkg
 ```
 
 To install hugo on Debian, run the following command:
@@ -132,7 +132,7 @@ nvm use 16
 
 To install Yarn, run the following command:
 ```bash
-brew install yarn
+brew install yarnpkg
 ```
 
 ### Static checks


### PR DESCRIPTION
Fix: Resolve conflict with Hadoop YARN by using yarnpkg alias

While attempting to install the required yarn locally, a conflict arose due to the presence of Hadoop's yarn. To address this issue, the yarnpkg alias was utilized to ensure a smooth installation.

issues: #909 
