### PR TITLE
Remove the privacy policy page with link to the ASF one

### DIFF
--- a/landing-pages/site/content/en/privacy-notice/_index.md
+++ b/landing-pages/site/content/en/privacy-notice/_index.md
@@ -5,47 +5,4 @@ linkTitle: "Privacy notice"
 
 ## Privacy Notice
 
-### Website Usage Privacy Policy
-
-Information about your use of this website is collected using server access logs and a tracking cookie. The collected information consists of the following:
-
-- The type of browser and operating system you use to access our site;
-- The date and time you access our site;
-- The pages you visit; and
-- The addresses of pages from where you followed a link to our site.
-
-Part of this information is gathered using a tracking cookie set by the Google Analytics service and handled by Google as described in their privacy policy. See your browser documentation for instructions on how to disable the cookie if you prefer not to share this data with Google.
-
-We use the gathered information to help us make our site more useful to visitors and to better understand how and when our site is used. We do not track or collect personally identifiable information or associate gathered data with any personally identifying information from other sources.
-
-By using this website, you consent to the collection of this data in the manner and for the purpose described above.
-
-### Privacy FAQ
-
-**What is Google Analytics?**
-
-Google Analytics is a simple, easy-to-use tool that helps website owners measure how users interact with website content. As a user navigates between web pages, Google Analytics provides website owners JavaScript tags (libraries) to record information about the page a user has seen, for example the URL of the page. The Google Analytics JavaScript libraries use HTTP Cookies to "remember" what a user has done on previous pages / interactions with the website. It makes it easy for website owners to understand how their site and app users are engaging with the content, e.g: which documentation page is mostly viewed and valuable.
-
-**Why do we use GA?**
-
-We use GA solely to gather the information that helps to make the site more useful to visitors and contributors, as well as to better understand how and when our site is used. We DO NOT track or collect personally identifiable information or associate gathered data with any personally identifying information from other sources.
-
-**What information is being collected?**
-
-GA provides us with information on the following 3 categories:
-
-- Audience reports: includes information about active users (interactions with the site in the last 1, 7, 14, or 30 days), where users come from (geographical location) and what language they speak (language of the browser), as well as the insight on the percentages of new and returning visitors.
-- Acquisition reports: includes information about how users are finding the website with detailed understanding of traffic and bounce rate. Website owners are able to see their main traffic categories, such as organic search, referral and direct, as well as the information about how many pages users view and how much time they spend on the website.
-- Behaviour reports: includes information on granulated metrics such as the average time a user spends on a webpage, total number of pageviews and the site’s  bounce rate, site’s most visited pages, and the most popular pages through which a user enters and exits your site (landing pages and exit pages), as well as insight on how quickly the website loads.
-
-Information collected has to do with your browser, time spent on each page, pages visited, and location (down to a granularity of city, not further). We do not track or collect personally identifiable information or associate gathered data with any personally identifying information from other sources.
-
-**Who has access to the data?**
-
-Project Management Committee (PMC) of the project, in this case Apache Airflow, has access to the data. However, if any of the committers have a strong case that requires the access, they can send an email to the private@ requesting the permission to have access for a limited period of time, and PMC has the right to decide whether to grant the access or not.
-
-**Resources**
-
-- [Google Analytics Cookie Usage](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage>)
-- [Google - Safeguarding your data](https://support.google.com/analytics/answer/6004245>)
-- [ASF Privacy Policy](https://www.apache.org/foundation/policies/privacy.html>)
+The website follows the [Privacy Policy of the Apache Software Foundation](https://privacy.apache.org/policies/privacy-policy-public.html>).


### PR DESCRIPTION
Since we are using Matomo and following the ASF policy we should remove the out-dated information about the Google Analytics and replace it with link to the ASF policy.

Fixes: #917