### PR TITLE
Hide survey page to permit infographic fix

### DIFF
--- a/landing-pages/site/content/en/survey/_index.html
+++ b/landing-pages/site/content/en/survey/_index.html
@@ -1,10 +1,10 @@
----
+<!-- ---
 title: "Airflow Survey 2023"
 linkTitle: "Airflow Survey 2023"
 menu:
   main:
     weight: 31
----
+--- -->
 
 <div>
   <img src="Astronomer - Airflow Survey 2023 - Results - Demographics - Landscape@2x.png"/>


### PR DESCRIPTION
The infographic on the survey page needs a fix. This comments out the page's front matter to hide the page temporarily in the meantime.