### PR TITLE
Improve community page styling for small displays

### DIFF
--- a/landing-pages/site/assets/scss/_community-page.scss
+++ b/landing-pages/site/assets/scss/_community-page.scss
@@ -62,11 +62,15 @@
     }
   }
 
-  &--grid {
-    display: grid;
-    grid-template-columns: 50% 50%;
-    grid-template-areas:
-      "dev user";
+  @media (min-width: $tablet) {
+    .community {
+      &--grid {
+      display: grid;
+      grid-template-columns: 50% 50%;
+      grid-template-areas:
+        "dev user";
+      }
+    }
   }
 
   &--dev {


### PR DESCRIPTION
We need responsive styling so the columns are not displayed side-by-side on mobile.

This uses a @media rule to apply the two-column layout on tablets and larger displays only. On mobile, a single-column format will apply instead.

Closes: https://github.com/apache/airflow-site/issues/934

![Firefox_Screenshot_2024-01-16T00-36-06 456Z](https://github.com/apache/airflow-site/assets/68482867/c2a8ae80-a57d-4042-b939-685b77f7ccde)
![Firefox_Screenshot_2024-01-16T00-35-22 484Z](https://github.com/apache/airflow-site/assets/68482867/176b0227-a42b-4c33-89b7-4c4f34b3c748)
