### PR TITLE
Better link to "enable_task_context_logger" in 2.8 blog

### DIFF
--- a/landing-pages/site/content/en/blog/airflow-2.8.0/index.md
+++ b/landing-pages/site/content/en/blog/airflow-2.8.0/index.md
@@ -68,7 +68,7 @@ information within a single log view.
 Presently, suppose a task is terminated by the scheduler before initiation, times out due to prolonged queuing, or transitions into a zombie state. In that case, it is not recorded in the task log. With this enhancement, in such situations,
 it becomes feasible to dispatch an error message to the task log for convenient visibility on the UI.
 
-This feature can be toggled, for more information [Look for “enable_task_context_logger” in the logging configuration documentation](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging)
+This feature can be toggled, for more information [see “enable_task_context_logger” in the logging configuration documentation](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-task-context-logger).
 
 ## Listener hooks for Datasets
 


### PR DESCRIPTION
We can deep link to the actual config, saves some scrolling :)