### PR TITLE
Add a link to Airflow security policy in bug reporting description

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -123,7 +123,14 @@ menu:
                 <a href="https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst">contribution guidelines</a>
                 to learn more about contributing.
             </p>
-            <p class="bodytext__medium--brownish-grey">If you are unsure if you are encountering a problem with Airflow, start a <a href="https://github.com/apache/airflow/discussions">GitHub Discussion</a> first.</p>
+            <p class="bodytext__medium--brownish-grey">
+                If you are unsure if you are encountering a problem with Airflow, start a
+                <a href="https://github.com/apache/airflow/discussions">GitHub Discussion</a> first.
+            </p>
+            <p class="bodytext__medium--brownish-grey">
+                If you want to raise a security issue, please take a look into the
+                <a href="https://github.com/apache/airflow/security/policy">Airflow security policy</a> first.
+            </p>
             {{< /accordion >}}
         </div>
     </div>


### PR DESCRIPTION
While I was searching for a way how to report a security issue I really had a hard time finding the right entry point - even though I was knowing docs were existing.
This PR adds a link to the section describing how to add a bug report.

Hope this helps for others seeking for the entry point