### PR TITLE
Update PMC members and Committers, sort by name as well

### DIFF
--- a/landing-pages/site/data/committers.json
+++ b/landing-pages/site/data/committers.json
@@ -6,12 +6,6 @@
     "nick": "amoghrajesh"
   },
   {
-    "name": "Andrey Anshin",
-    "github": "https://github.com/taragolis",
-    "image": "https://github.com/taragolis.png",
-    "nick": "taragolis"
-  },
-  {
     "name": "Aneesh Joseph",
     "github": "https://github.com/aneesh-joseph",
     "image": "https://github.com/aneesh-joseph.png",
@@ -30,6 +24,12 @@
     "nick": "milton0825"
   },
   {
+    "name": "Dennis Ferruzzi",
+    "github": "https://github.com/ferruzzi",
+    "image": "https://github.com/ferruzzi.png",
+    "nick": "ferruzzi"
+  },
+  {
     "name": "Felix Uellendall",
     "github": "https://github.com/feluelle",
     "image": "https://github.com/feluelle.png",
@@ -40,6 +40,18 @@
     "github": "https://github.com/jhtimmins",
     "image": "https://github.com/jhtimmins.png",
     "nick": "jhtimmins"
+  },
+  {
+    "name": "Jens Scheffler",
+    "github": "https://github.com/jscheffl",
+    "image": "https://github.com/jscheffl.png",
+    "nick": "jscheffl"
+  },
+  {
+    "name": "Jiajie Zhong",
+    "github": "https://github.com/zhongjiajie",
+    "image": "https://github.com/zhongjiajie.png",
+    "nick": "zhongjiajie"
   },
   {
     "name": "Josh Fell",
@@ -54,10 +66,22 @@
     "nick": "jmcarp"
   },
   {
-    "name": "Jiajie Zhong",
-    "github": "https://github.com/zhongjiajie",
-    "image": "https://github.com/zhongjiajie.png",
-    "nick": "zhongjiajie"
+    "name": "Leah E. Cole",
+    "github": "https://github.com/leahecole",
+    "image": "https://github.com/leahecole.png",
+    "nick": "leahecole"
+  },
+  {
+    "name": "Maciej Obuchowski",
+    "github": "https://github.com/mobuchowski",
+    "image": "https://github.com/mobuchowski.png",
+    "nick": "mobuchowski"
+  },
+  {
+    "name": "Malthe Borch",
+    "github": "https://github.com/malthe",
+    "image": "https://github.com/malthe.png",
+    "nick": "malthe"
   },
   {
     "name": "Niko Oliveira",
@@ -66,10 +90,34 @@
     "nick": "o-nikolas"
   },
   {
+    "name": "Pankaj Koti",
+    "github": "https://github.com/pankajkoti",
+    "image": "https://github.com/pankajkoti.png",
+    "nick": "pankajkoti"
+  },
+  {
     "name": "Pankaj Singh",
     "github": "https://github.com/pankajastro",
     "image": "https://github.com/pankajastro.png",
     "nick": "pankajastro"
+  },
+  {
+    "name": "Patrick Leo Tardif",
+    "github": "https://github.com/patrickleotardif",
+    "image": "https://github.com/patrickleotardif.png",
+    "nick": "patrickleotardif"
+  },
+  {
+    "name": "Phani Kumar",
+    "github": "https://github.com/phanikumv",
+    "image": "https://github.com/phanikumv.png",
+    "nick": "phanikumv"
+  },
+  {
+    "name": "Ping Zhang",
+    "github": "https://github.com/pingzh",
+    "image": "https://github.com/pingzh.png",
+    "nick": "pingzh"
   },
   {
     "name": "Qian Yu",
@@ -90,46 +138,28 @@
     "nick": "ryw"
   },
   {
-    "name": "Leah Cole",
-    "github": "https://github.com/leahecole",
-    "image": "https://github.com/leahecole.png",
-    "nick": "leahecole"
-  },
-  {
-    "name": "Malthe Borch",
-    "github": "https://github.com/malthe",
-    "image": "https://github.com/malthe.png",
-    "nick": "malthe"
-  },
-  {
-    "name": "Pankaj Koti",
-    "github": "https://github.com/pankajkoti",
-    "image": "https://github.com/pankajkoti.png",
-    "nick": "pankajkoti"
-  },
-  {
-    "name": "Patrick Leo Tardif",
-    "github": "https://github.com/pltardif",
-    "image": "https://github.com/pltardif.png",
-    "nick": "pltardif"
-  },
-  {
-    "name": "Ping Zhang",
-    "github": "https://github.com/pingzh",
-    "image": "https://github.com/pingzh.png",
-    "nick": "pingzh"
-  },
-  {
     "name": "Ryan Hamilton",
     "github": "https://github.com/ryanahamilton",
     "image": "https://github.com/ryanahamilton.png",
     "nick": "ryanahamilton"
   },
   {
+    "name": "Utkarsh Sharma",
+    "github": "https://github.com/utkarsharma2",
+    "image": "https://github.com/utkarsharma2.png",
+    "nick": "utkarsharma2"
+  },
+  {
     "name": "Vikram Koka",
     "github": "https://github.com/vikramkoka",
     "image": "https://github.com/vikramkoka.png",
     "nick": "vikramkoka"
+  },
+  {
+    "name": "Vincent Beck",
+    "github": "https://github.com/vincbeck",
+    "image": "https://github.com/vincbeck.png",
+    "nick": "vincbeck"
   },
   {
     "name": "Xinbin Huang",

--- a/landing-pages/site/data/pmc.json
+++ b/landing-pages/site/data/pmc.json
@@ -18,6 +18,12 @@
     "nick": "alexvanboxel"
   },
   {
+    "name": "Andrey Anshin",
+    "github": "https://github.com/taragolis",
+    "image": "https://github.com/taragolis.png",
+    "nick": "taragolis"
+  },
+  {
     "name": "Arthur Wiedmer",
     "github": "https://github.com/artwr",
     "image": "https://github.com/artwr.png",


### PR DESCRIPTION
I realized that my name is missing in committers list. Double checked the list of PMC members and committers from / via https://home.apache.org/committers-by-project.html#airflow

Also I realized that the list was not consistently sorted, so re-sorted some members.

Maybe in future this would be cool to be machine-readable, don't know (immediately) how to implement... so here is a manual sync.

As a follow-up I'll update the docs for new committers in the Airflow mono-repo.