### PR TITLE
Add Code of Conduct to Airflow Site

### DIFF
--- a/landing-pages/site/config.toml
+++ b/landing-pages/site/config.toml
@@ -147,6 +147,9 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 [[params.links.policies]]
     name = "Privacy notice"
     url = "/privacy-notice/"
+[[params.links.policies]]
+    name = "Code of Conduct"
+    url = "/code-of-conduct/"
 
 [related]
 threshold = 50.0

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -1,8 +1,8 @@
 ---
 title: Code of Conduct
-menu: 
-  main: 
-    weight: 1
+menu:
+main:
+weight: 1
 ---
 <h4>Community Code of Conduct</h4>
 <p>All Airflow Community groups abide by

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -1,0 +1,7 @@
+---
+title: Code of Conduct
+menu:
+  main: 
+    weight: 1
+---
+All Airflow Community groups abide by The Apache Software Foundation’s (ASF) Code of Conduct. Below, please find a breakdown of how that code applies to Airflow Slack and in-person Meetups.

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -1,4 +1,4 @@
-
+---
 title: Code of Conduct
 menu: 
   main: 

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -1,8 +1,8 @@
 ---
 title: Code of Conduct
 menu:
-main:
-weight: 1
+  main:
+    weight: 1
 ---
 <h4>Community Code of Conduct</h4>
 <p>All Airflow Community groups abide by

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -1,7 +1,4 @@
----
-[[params.links.codeofconduct]]
-    name = "Code of Conduct"
-    url = "/code-of-conduct/"
+
 title: Code of Conduct
 menu: 
   main: 
@@ -10,15 +7,13 @@ menu:
 <h4>Community Code of Conduct</h4>
 <p>All Airflow Community groups abide by
   <a target="_blank" href="https://apache.org/foundation/policies/conduct">
-    <span style="color:rgb(17, 85, 204);">The Apache Software Foundation’s (ASF) Code of Conduct</span>
+    The Apache Software Foundation’s (ASF) Code of Conduct
   </a>. Below, please find a breakdown of how that code applies to Airflow Slack and in-person Meetups</p>
 
 <h4>Airflow Slack Guidelines</h4>
 <p>
   <strong>Airflow Slack abides by
   </strong>
-  <a target="_blank" href="https://apache.org/foundation/policies/conduct">
-    <span style="color:rgb(17, 85, 204);">
       <strong>The Apache Foundation’s Code of Conduct</strong>
     </span>
   </a>
@@ -39,7 +34,6 @@ menu:
       <strong>Make It Easy to Help You:
       </strong>When posting a question, make sure you have done your research on the topic prior to posting. Provide as much information as you can, including documentation, your tech stack, and anything else you think will be helpful. In a nutshell, do not ask just to ask. Ask with the intention of making it easy for others to help you.
       <a target="_blank" href="https://dontasktoask.com/">
-        <span style="color:rgb(17, 85, 204);">Go here for a further breakdown</span>
       </a>.
       &nbsp;</li>
     <li>
@@ -56,7 +50,6 @@ menu:
       <strong>Respect Community Guidelines and Etiquette:</strong>
       Follow the guidelines and
       <a target="_blank" href="https://apache.org/foundation/policies/conduct">
-        <span style="color:rgb(17, 85, 204);">Code of Conduct</span>
       </a>
       established by the Apache Software Foundation (ASF). Be respectful, polite, and considerate in your interactions. Avoid using offensive language, making personal attacks, or engaging in any form of harassment. Encourage constructive discussions and collaboration among members.
     </li>
@@ -102,7 +95,7 @@ menu:
       <strong>Follow the Code of Conduct:</strong>
       Adhere to the
       <a target="_blank" href="https://apache.org/foundation/policies/conduct">
-        <span style="color:rgb(17, 85, 204);">Apache Software Foundation's Code of Conduct</span>
+        Apache Software Foundation's Code of Conduct
       </a>. Be respectful, courteous, and patient in your interactions, and avoid any form of harassment or discrimination.</li>
   </ul>
   <p>Remember that the Airflow Slack community is a place for open discussion, collaboration, and learning. By following these rules and engaging positively, you can build trust and credibility within the community while representing your company in a respectful and constructive manner.</p>
@@ -149,10 +142,7 @@ menu:
     </span>
   </p>
   <p>If you notice a person violating the Airflow Slack Community Guidelines or The<a target="_blank" href="https://apache.org/foundation/policies/conduct">
-      <span style="color:rgb(17, 85, 204);">
-        <strong></strong>
-      </span>
-      <span style="color:rgb(17, 85, 204);">Apache Foundation’s Code of Conduct</span>
+        <strong></strong> Apache Foundation’s Code of Conduct
     </a>, please direct message a member of the Project Management Committee (PMC)&nbsp; or email private@airflow.apache.org and link (if possible) to the post and/or thread containing the violation along with the slack handle of the person that committed it.</p>
   <p>Suggested PMC Members to Contact:</p>
   <ul>
@@ -160,9 +150,7 @@ menu:
     <li>Jed Cunningham</li>
     <li>Kaxil Naik</li>
     <li>A full list of PMC Members can be found on
-      <a target="_blank" href="https://airflow.apache.org/community/">
-        <span style="color:rgb(17, 85, 204);">the Community Page</span>
-      </a>
+      <a target="_blank" href="https://airflow.apache.org/community/"<the Community Page</a>
       (scroll down)</li>
   </ul>
   <p>If a person violates the Slack Code of Conduct, the admins may take whatever action they deem necessary, including expulsion from the workspace.
@@ -171,16 +159,11 @@ menu:
   <p>
     <strong>Airflow Meetups abide by
     </strong>
-    <a target="_blank" href="https://apache.org/foundation/policies/conduct">
-      <span style="color:rgb(17, 85, 204);">
-        <strong>The Apache Software Foundation’s Code of Conduct</strong>
-      </span>
-    </a>
-    <strong>. In addition to those primary guidelines, these policies are specifically for In-Person Meetups.</strong>
+    <a target="_blank" href="https://apache.org/foundation/policies/conduct"> <strong>The Apache Software Foundation’s Code of Conduct</strong>
+    </a> <strong>. In addition to those primary guidelines, these policies are specifically for In-Person Meetups.</strong>
   </p>
   <p>Airflow Meet-ups are a space for big data enthusiasts around the world to meet in person to network, learn, and grow their careers. With Meet-ups happening in 10+ cities globally, it is up to the members in attendance to uphold
     <a target="_blank" href="https://apache.org/foundation/policies/conduct">
-      <span style="color:rgb(17, 85, 204);">
         <strong>The Apache Software Foundation’s Code of Conduct</strong>
       </span>
     </a>

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -153,7 +153,7 @@ menu:
         <strong></strong>
       </span>
       <span style="color:rgb(17, 85, 204);">Apache Foundation’s Code of Conduct</span>
-    </a>, please direct message a member of the Project Management Committee (PMC)&nbsp; and link (if possible) to the post and/or thread containing the violation along with the slack handle of the person that committed it.</p>
+    </a>, please direct message a member of the Project Management Committee (PMC)&nbsp; or email private@airflow.apache.org and link (if possible) to the post and/or thread containing the violation along with the slack handle of the person that committed it.</p>
   <p>Suggested PMC Members to Contact:</p>
   <ul>
     <li>Jarek Potiuk</li>

--- a/landing-pages/site/content/en/codeofconduct/_index.html
+++ b/landing-pages/site/content/en/codeofconduct/_index.html
@@ -1,7 +1,208 @@
 ---
+[[params.links.codeofconduct]]
+    name = "Code of Conduct"
+    url = "/code-of-conduct/"
 title: Code of Conduct
-menu:
+menu: 
   main: 
     weight: 1
 ---
-All Airflow Community groups abide by The Apache Software Foundation’s (ASF) Code of Conduct. Below, please find a breakdown of how that code applies to Airflow Slack and in-person Meetups.
+<h4>Community Code of Conduct</h4>
+<p>All Airflow Community groups abide by
+  <a target="_blank" href="https://apache.org/foundation/policies/conduct">
+    <span style="color:rgb(17, 85, 204);">The Apache Software Foundation’s (ASF) Code of Conduct</span>
+  </a>. Below, please find a breakdown of how that code applies to Airflow Slack and in-person Meetups</p>
+
+<h4>Airflow Slack Guidelines</h4>
+<p>
+  <strong>Airflow Slack abides by
+  </strong>
+  <a target="_blank" href="https://apache.org/foundation/policies/conduct">
+    <span style="color:rgb(17, 85, 204);">
+      <strong>The Apache Foundation’s Code of Conduct</strong>
+    </span>
+  </a>
+  <strong>. In addition to those primary guidelines, these policies are specifically for Airflow Slack.</strong>
+
+  <p>The Airflow Slack community contains 40,000+ members and continues to grow. Because this community is run by the very practitioners who build in Airflow daily, our members feel a sense of camaraderie, ownership, and comfortability here.
+    &nbsp;</p>
+  <p>Our mission is to preserve the integrity of this community. So along with our members, we have codified what it means to be a valuable participant in Airflow Slack. Thank you for reviewing our guidelines, and by doing so helping to grow a community we can all call home.</p>
+  <p>
+    <span style="text-decoration:underline;">
+      <strong>Channel Guidelines</strong>
+    </span>
+  </p>
+  <p>There are 75+ Channels in the Airflow Slack Community. To view them all, please select “Browse Channels”. Only post in a Channel if the information is pertinent to that channel. If you are unsure if you should be posting in a specific channel, please go to “Browse Channels” to see if there is a more relevant space to post. Please note that Airflow Slack Community members help on a volunteer basis during their free time. So, we encourage all Airflow Slack members to be patient when asking a question in a channel. When posting in channels in the Airflow Slack community, it's important to maintain a respectful and productive atmosphere. Here are some things to keep in mind:
+  </p>
+  <ul>
+    <li>
+      <strong>Make It Easy to Help You:
+      </strong>When posting a question, make sure you have done your research on the topic prior to posting. Provide as much information as you can, including documentation, your tech stack, and anything else you think will be helpful. In a nutshell, do not ask just to ask. Ask with the intention of making it easy for others to help you.
+      <a target="_blank" href="https://dontasktoask.com/">
+        <span style="color:rgb(17, 85, 204);">Go here for a further breakdown</span>
+      </a>.
+      &nbsp;</li>
+    <li>
+      <strong>Stay On-Topic:</strong>
+      Ensure that your messages are relevant to the specific channel's purpose. Avoid posting unrelated content or engaging in off-topic discussions that could clutter the channel and distract community members from the main focus of the conversation. Avoid hijacking existing threads that are discussing a similar topic that you planned to post. Instead, start a new thread about your topic. Most problems are nuanced and different, so it’s important to separate them to avoid confusion.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Use Descriptive and Informative Titles:</strong>
+      When starting a new discussion or asking a question, use clear and descriptive titles or subjects that provide context. This helps other members quickly understand the nature of your message and whether they can contribute or benefit from it.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Respect Community Guidelines and Etiquette:</strong>
+      Follow the guidelines and
+      <a target="_blank" href="https://apache.org/foundation/policies/conduct">
+        <span style="color:rgb(17, 85, 204);">Code of Conduct</span>
+      </a>
+      established by the Apache Software Foundation (ASF). Be respectful, polite, and considerate in your interactions. Avoid using offensive language, making personal attacks, or engaging in any form of harassment. Encourage constructive discussions and collaboration among members.
+    </li>
+    <li>
+      <strong>Avoid Spammy Behavior:</strong>
+      Refrain from excessive or unsolicited marketing messages, sales pitches, or product advertisements. Use private messages for one-on-one conversations about your offerings, and only when community members express interest.</li>
+  </ul>
+  <p>By adhering to these rules, you can contribute positively to the Airflow Slack community, promote productive discussions, and maintain a welcoming and respectful environment for all participants.
+  </p>
+  <p>
+    <span style="text-decoration:underline;">
+      <strong>Spamming</strong>
+    </span>
+  </p>
+  <p>Any person spamming within the Airflow Slack Community will immediately have their Slack account inactivated. Spamming includes:
+  </p>
+  <ul>
+    <li>Posting links in channels advertising something for personal gain that is not related to Airflow.</li>
+    <li>Direct messaging members with the intent to sell.</li>
+    <li>Posting the same link and/or message multiple times.</li>
+  </ul>
+  <p>
+    <span style="text-decoration:underline;">
+      <strong>Vendors</strong>
+    </span>
+  </p>
+  <p>Vendors are an important part of the Airflow ecosystem. However, given that this is an open source community, we have strict guidelines for how to engage as a vendor within this community. If you are a vendor, please review carefully:&nbsp;</p>
+  <ul>
+    <li>Transparency is Key: Always clearly identify yourself as a vendor or representative of your company in your Slack username or profile information. This transparency helps community members understand your affiliation and intentions.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Respect the Community's Focus:</strong>
+      Ensure that your posts align with the Apache Airflow community's primary goal of discussing, sharing knowledge, and solving issues related to Airflow. Avoid excessive self-promotion or off-topic discussions.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Provide Value First:</strong>
+      Focus on delivering value to the community before promoting your products or services. Contribute by answering questions, providing insights, or sharing helpful resources related to Apache Airflow.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Follow the Code of Conduct:</strong>
+      Adhere to the
+      <a target="_blank" href="https://apache.org/foundation/policies/conduct">
+        <span style="color:rgb(17, 85, 204);">Apache Software Foundation's Code of Conduct</span>
+      </a>. Be respectful, courteous, and patient in your interactions, and avoid any form of harassment or discrimination.</li>
+  </ul>
+  <p>Remember that the Airflow Slack community is a place for open discussion, collaboration, and learning. By following these rules and engaging positively, you can build trust and credibility within the community while representing your company in a respectful and constructive manner.</p>
+  <p>
+    <span style="text-decoration:underline;">
+      <strong>Direct Messages</strong>
+    </span>
+  </p>
+  <p>Sending direct messages (DMs) in the Airflow Slack community can be a valuable way to engage in one-on-one conversations and seek assistance. However, it's crucial to maintain professionalism and respect others' boundaries. Here are five rules to follow when sending DMs in the Airflow Slack community:</p>
+  <ul>
+    <li>
+      <strong>Respect Consent and Privacy:
+      </strong>We encourage you to ask for permission before initiating a direct message conversation with another community member. Unsolicited DMs can be seen as intrusive, so respect their decision if they decline or do not respond.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Keep Troubleshooting Questions Public:
+      </strong>Kindly avoid seeking troubleshooting or asking questions via private messages for three key reasons. Firstly, public discussions promote shared learning, benefiting all members. Secondly, by posting questions openly, you allow others to offer their assistance. Lastly, our community thrives on mutual support; private messages may strain volunteers. Embracing open discussions preserves our helpful and resourceful environment.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Stay on Topic:</strong>
+      Keep your DM conversations focused on relevant topics related to Apache Airflow or community-related discussions. Avoid using DMs for personal or unrelated matters.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Be Courteous and Professional:</strong>
+      Maintain a polite and respectful tone in your DMs, just as you would in public channels. Avoid using offensive language, making personal attacks, or engaging in any form of harassment.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Avoid Spam and Unsolicited Promotion:</strong>
+      Do not use DMs to spam or excessively promote products, services, or solicitations. Only share information or offers when the recipient has shown a genuine interest or consented to receive such messages.</li>
+  </ul>
+  <ul>
+    <li>
+      <strong>Use Group DMs Appropriately:</strong>
+      When creating group DMs, ensure that all participants are interested in the conversation's topic and that it remains relevant to the community. Respect the privacy and preferences of all participants.</li>
+  </ul>
+  <p>Remember that direct messages should be used as a tool for collaboration, seeking assistance, or engaging in constructive discussions privately. By following these rules, you can maintain a positive and respectful environment when using DMs within the Apache Airflow Slack community.</p>
+  <p>
+    <span style="text-decoration:underline;">
+      <strong>Reporting a Problem</strong>
+    </span>
+  </p>
+  <p>If you notice a person violating the Airflow Slack Community Guidelines or The<a target="_blank" href="https://apache.org/foundation/policies/conduct">
+      <span style="color:rgb(17, 85, 204);">
+        <strong></strong>
+      </span>
+      <span style="color:rgb(17, 85, 204);">Apache Foundation’s Code of Conduct</span>
+    </a>, please direct message a member of the Project Management Committee (PMC)&nbsp; and link (if possible) to the post and/or thread containing the violation along with the slack handle of the person that committed it.</p>
+  <p>Suggested PMC Members to Contact:</p>
+  <ul>
+    <li>Jarek Potiuk</li>
+    <li>Jed Cunningham</li>
+    <li>Kaxil Naik</li>
+    <li>A full list of PMC Members can be found on
+      <a target="_blank" href="https://airflow.apache.org/community/">
+        <span style="color:rgb(17, 85, 204);">the Community Page</span>
+      </a>
+      (scroll down)</li>
+  </ul>
+  <p>If a person violates the Slack Code of Conduct, the admins may take whatever action they deem necessary, including expulsion from the workspace.
+  </p>
+  <h4>Meetup Guidelines</h4>
+  <p>
+    <strong>Airflow Meetups abide by
+    </strong>
+    <a target="_blank" href="https://apache.org/foundation/policies/conduct">
+      <span style="color:rgb(17, 85, 204);">
+        <strong>The Apache Software Foundation’s Code of Conduct</strong>
+      </span>
+    </a>
+    <strong>. In addition to those primary guidelines, these policies are specifically for In-Person Meetups.</strong>
+  </p>
+  <p>Airflow Meet-ups are a space for big data enthusiasts around the world to meet in person to network, learn, and grow their careers. With Meet-ups happening in 10+ cities globally, it is up to the members in attendance to uphold
+    <a target="_blank" href="https://apache.org/foundation/policies/conduct">
+      <span style="color:rgb(17, 85, 204);">
+        <strong>The Apache Software Foundation’s Code of Conduct</strong>
+      </span>
+    </a>
+    at these events. Below are the policies and procedures on how best to do that.&nbsp;</p>
+  <p>
+    <strong>Anti-Harassment Policy</strong>
+  </p>
+  <p>Airflow is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form. Participants violating these rules may be sanctioned or expelled, at the discretion of the event organizers.</p>
+  <p>Harassment includes offensive verbal comments, deliberate intimidation, stalking, following, unwanted photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+  <p>Sexual language and imagery will not be tolerated in any talk or activity related to the event. Presenters should also refrain from using sexualized images, activities, or other material.</p>
+  <p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the event.</p>
+  <p>If you encounter any of these behaviors at an Airflow Meet-up, please inform the organizers immediately.&nbsp;</p>
+  <p>
+    <strong>ADA Compliance</strong>
+  </p>
+  <p>At Airflow Meetups, we are committed to ensuring that our event is accessible and inclusive for all attendees. We strive to provide a welcoming and accommodating environment where everyone can fully participate and enjoy the experience. We have taken a number of steps to make our events accessible to individuals with diverse needs, and we are continuously working to improve our accessibility efforts. If you need assistance in any of the below areas, please message your event organizer on Meetup.com and they will accommodate you.</p>
+  <ul>
+    <li>Venue Accessibility</li>
+    <li>Assistive Devices</li>
+    <li>Special Dietary Needs</li>
+    <li>Quiet Spaces</li>
+    <li>Transportation</li>
+    <li>Registration Assistance</li>
+  </ul>
+</p>


### PR DESCRIPTION
Currently, the Airflow website does not link out to the Code of Conduct. I propose we add a link to the Code of Conduct from the footer of the website where the "license, donate, privacy policy, etc" section is. 