### PR TITLE
Update slack channel names following new naming schemes

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -87,8 +87,8 @@ menu:
                     After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join
                     <a href="https://apache-airflow.slack.com/messages/user-troubleshooting">#user-troubleshooting</a>
                     to ask for help with using Airflow.
-                    <a href="https://apache-airflow.slack.com/messages/user-best-practices">#user-best-practices</a> and
-                    to ask for best practices with using Airflow, and to share your best practices.
+                    Consider joining <a href="https://apache-airflow.slack.com/messages/user-best-practices">#user-best-practices</a>
+                    to ask about best practices with using Airflow, and to share your best practices.
                 </p>
             </ol>
             {{< /accordion >}}

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -27,6 +27,17 @@ menu:
                     For answers to ad hoc questions, try asking in the official <b>Airflow Slack</b> first. See <b>"Ask a question"</b> below for details and additional resources.
                 </p>
             {{< /accordion >}}
+            {{< accordion title="Join the community on Slack" description="Connect with other contributors" logo_path="icons/ask-question-icon.svg" open="true">}}
+            <ol class="counter-blue mx-auto">
+                <p class="bodytext__medium--brownish-grey">
+                    After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join
+                    <a href="https://apache-airflow.slack.com/messages/contributors">#new-contributors</a>
+                    when you have questions and attempt to do your first contributions.
+                    <a href="https://apache-airflow.slack.com/messages/contributors">#contributors</a>
+                    to discuss more in depth contributing to Airflow.
+                </p>
+            </ol>
+            {{< /accordion >}}
             {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://apache.us14.list-manage.com/track/click?u=fe7ef7a8dbb32933f30a10466&id=ba35da0c2d&e=a2e8531eaf) on recent events and communications in the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
             <p class="bodytext__medium--brownish-grey">You will learn about:</p>
             <ul class="ticks-blue mx-auto">
@@ -70,13 +81,14 @@ menu:
     <div class="community--user">
         <div class="community--accordion-container">
             <h6 class="community--header-persona">Are you a user?</h6>
-            {{< accordion title="Join the community on Slack" description="Connect with other users, get help, and stay up-to-date on developments in the project." logo_path="icons/ask-question-icon.svg" open="true">}}
+            {{< accordion title="Join the community on Slack" description="Connect with other users, get help, exchange best practices with other users." logo_path="icons/ask-question-icon.svg" open="true">}}
             <ol class="counter-blue mx-auto">
                 <p class="bodytext__medium--brownish-grey">
                     After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join
-                    <a href="https://apache-airflow.slack.com/messages/troubleshooting">#troubleshooting</a> and
-                    <a href="https://apache-airflow.slack.com/messages/development">#development</a>
-                    to ask for help with using and developing Airflow, respectively.
+                    <a href="https://apache-airflow.slack.com/messages/user-troubleshooting">#user-troubleshooting</a> and
+                    to ask for help with using aAirflow, respectively.
+                    <a href="https://apache-airflow.slack.com/messages/user-best-practices">#user-best-practices</a> and
+                    to ask for best practices with using Airflow, and to share your best practices.
                 </p>
             </ol>
             {{< /accordion >}}

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -85,8 +85,8 @@ menu:
             <ol class="counter-blue mx-auto">
                 <p class="bodytext__medium--brownish-grey">
                     After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join
-                    <a href="https://apache-airflow.slack.com/messages/user-troubleshooting">#user-troubleshooting</a> and
-                    to ask for help with using aAirflow, respectively.
+                    <a href="https://apache-airflow.slack.com/messages/user-troubleshooting">#user-troubleshooting</a>
+                    to ask for help with using Airflow.
                     <a href="https://apache-airflow.slack.com/messages/user-best-practices">#user-best-practices</a> and
                     to ask for best practices with using Airflow, and to share your best practices.
                 </p>

--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -33,7 +33,7 @@ menu:
                     After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join
                     <a href="https://apache-airflow.slack.com/messages/contributors">#new-contributors</a>
                     when you have questions and attempt to do your first contributions.
-                    <a href="https://apache-airflow.slack.com/messages/contributors">#contributors</a>
+                    Join <a href="https://apache-airflow.slack.com/messages/contributors">#contributors</a>
                     to discuss more in depth contributing to Airflow.
                 </p>
             </ol>


### PR DESCRIPTION
Following LAZY CONSENSUS on devlist:

https://lists.apache.org/thread/v9s6pc46o96y7xpd519mflnlx7r8sslo

we rename the channels in our docs.