### PR TITLE
Fix up code of conduct

### DIFF
--- a/landing-pages/site/content/en/code-of-conduct/_index.html
+++ b/landing-pages/site/content/en/code-of-conduct/_index.html
@@ -150,7 +150,7 @@ menu:
     <li>Jed Cunningham</li>
     <li>Kaxil Naik</li>
     <li>A full list of PMC Members can be found on
-      <a target="_blank" href="https://airflow.apache.org/community/"<the Community Page</a>
+      <a target="_blank" href="https://airflow.apache.org/community/">the Community Page</a>
       (scroll down)</li>
   </ul>
   <p>If a person violates the Slack Code of Conduct, the admins may take whatever action they deem necessary, including expulsion from the workspace.


### PR DESCRIPTION
Move the page to the right url, where we link to in the footer.
Fix broken anchor close.