### PR TITLE
Add `frame-src` to CSP so YouTube videos are viewable

### DIFF
--- a/landing-pages/site/layouts/partials/hooks/head-end.html
+++ b/landing-pages/site/layouts/partials/hooks/head-end.html
@@ -53,4 +53,7 @@
 {{ $vendorsHeader := index . "vendors~header" }}
 <link rel="preload" href="{{ relURL $vendorsHeader.js }}" as="script">
 
+<!-- CSP for YouTube videos -->
+<meta http-equiv="Content-Security-Policy" content="frame-src 'https://www.youtube.com'">
+
 {{ end }}


### PR DESCRIPTION
The site's CSP is blocking YouTube videos currently.

This adds a `meta` tag to head-end.html to allow `frame-src` directives from YouTube.