### PR TITLE
Retry fixing CSP for video iframes in head-end

### DIFF
--- a/landing-pages/site/layouts/partials/hooks/head-end.html
+++ b/landing-pages/site/layouts/partials/hooks/head-end.html
@@ -54,6 +54,6 @@
 <link rel="preload" href="{{ relURL $vendorsHeader.js }}" as="script">
 
 <!-- CSP for YouTube video iframes -->
-<meta http-equiv="Content-Security-Policy" content="frame-src 'self' https://www.youtube.com;">
+<meta http-equiv="Content-Security-Policy" content="frame-src https://www.youtube.com;">
 
 {{ end }}


### PR DESCRIPTION
The previous attempt failed due to the inclusion of `self` in the directive. This includes only the source, `https://www.youtube.com`.