### PR TITLE
Remove github-pages configuration from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,7 +36,5 @@ github:
         strict: true
       required_linear_history: true
 
-  ghp_branch: gh-pages
-
 publish:
   whoami:   gh-pages


### PR DESCRIPTION
We seem to be running gh-pages builds in parallel to the INFRA managed builds - pretty much since the beginning of our site building. That's useless, really because we are not using gh-pages generated site and for quite some time builds to run the pages fail because the default runners used by GitHub to run github pages are failing due to disk space not being enough for our site.

This change **SHOULD** disable gh-pages for the airflow-site project.