### PR TITLE
Remove Code of Conduct from the main menu

### DIFF
--- a/landing-pages/site/content/en/code-of-conduct/_index.html
+++ b/landing-pages/site/content/en/code-of-conduct/_index.html
@@ -1,8 +1,5 @@
 ---
 title: Code of Conduct
-menu:
-  main:
-    weight: 1
 ---
 <h4>Community Code of Conduct</h4>
 <p>All Airflow Community groups abide by


### PR DESCRIPTION
We don't need the Code of Conduct to be the first menu item in our main menu :)