### PR TITLE
Add new meetup groups

### DIFF
--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -153,5 +153,4 @@
     "members": 127,
     "url": "https://www.meetup.com/pl-PL/warsaw-apache-airflow-meetup-group/"
   }
-
 ]

--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -145,5 +145,13 @@
     "date": "",
     "members": 30,
     "url": "https://www.meetup.com/taipei-py/"
+  },
+  {
+    "city": "Warsaw",
+    "country": "Poland",
+    "date": "",
+    "members": 127,
+    "url": "https://www.meetup.com/pl-PL/warsaw-apache-airflow-meetup-group/"
   }
+
 ]

--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -7,6 +7,90 @@
     "url": "https://www.meetup.com/Amsterdam-Airflow-meetup/"
   },
   {
+    "city": "Bangalore",
+    "country": "India",
+    "date": "",
+    "members": 1717,
+    "url": "https://www.meetup.com/Bangalore-Apache-Airflow-Meetup/"
+  },
+  {
+    "city": "Charlotte",
+    "country": "USA",
+    "date": "",
+    "members": 73,
+    "url": "https://www.meetup.com/charlotte-apache-airflow-meetup/"
+  },
+  {
+    "city": "Chicago",
+    "country": "USA",
+    "date": "",
+    "members": 118,
+    "url": "https://www.meetup.com/chicago-apache-airflow-meetup-group/"
+  },
+  {
+    "city": "Hyderabad",
+    "country": "India",
+    "date": "",
+    "members": 510,
+    "url": "https://www.meetup.com/hyderabad-apache-airflow-meetup-group/"
+  },
+  {
+    "city": "Seoul",
+    "country": "Korea",
+    "date": "",
+    "members": 67,
+    "url": "https://www.meetup.com/apache-airflow-users-korea/"
+  },
+  {
+    "city": "Lisbon",
+    "country": "Portugal",
+    "date": "",
+    "members": 13,
+    "url": "https://www.meetup.com/lisbon-apache-airflow-meetup-group/"
+  },
+  {
+    "city": "London",
+    "country": "United Kingdom",
+    "date": "",
+    "members": 1163,
+    "url": "https://www.meetup.com/London-Apache-Airflow-Meetup/"
+  },
+  {
+    "city": "Melbourne",
+    "country": "Australia",
+    "date": "",
+    "members": 209,
+    "url": "https://www.meetup.com/Melbourne-Apache-Airflow-Meetup/"
+  },
+  {
+    "city": "New York",
+    "country": "USA",
+    "date": "",
+    "members": 1875,
+    "url": "https://www.meetup.com/NYC-Apache-Airflow-Meetup/"
+  },
+  {
+    "city": "Paris",
+    "country": "France",
+    "date": "",
+    "members": 1306,
+    "url": "https://www.meetup.com/Paris-Apache-Airflow-Meetup/"
+  },
+  {
+    "city": "Portland",
+    "country": "USA",
+    "date": "",
+    "members": 143,
+    "url": "https://www.meetup.com/Portland-Apache-Airflow-Meetup/"
+  },
+  {
+    "city": "Prague",
+    "country": "Czech Republic",
+    "date": "",
+    "members": 115,
+    "url": "https://www.meetup.com/prague-airflow-meetup-group/"
+  },
+  {
     "city": "Tel Aviv-Yafo",
     "country": "Israel",
     "date": "",
@@ -14,25 +98,11 @@
     "url": "https://www.meetup.com/tel-aviv-apache-airflow-meetup/"
   },
   {
-    "city": "San Francisco",
+    "city": "San Francisco Bay Area",
     "country": "USA",
     "date": "",
-    "members": 2088,
+    "members": 2178,
     "url": "https://www.meetup.com/Bay-Area-Apache-Airflow-Incubating-Meetup/"
-  },
-  {
-    "city": "London",
-    "country": "United Kingdom",
-    "date": "",
-    "members": 1139,
-    "url": "https://www.meetup.com/London-Apache-Airflow-Meetup/"
-  },
-  {
-    "city": "New York",
-    "country": "USA",
-    "date": "",
-    "members": 1761,
-    "url": "https://www.meetup.com/NYC-Apache-Airflow-Meetup/"
   },
   {
     "city": "Washington D.C.",
@@ -42,32 +112,11 @@
     "url": "https://www.meetup.com/dc-area-apache-airflow-meetup/"
   },
   {
-    "city": "Chicago",
-    "country": "USA",
+    "city": "São Paulo",
+    "country": "Brazil",
     "date": "",
-    "members": 114,
-    "url": "https://www.meetup.com/chicago-apache-airflow-meetup-group/"
-  },
-  {
-    "city": "Melbourne",
-    "country": "Australia",
-    "date": "",
-    "members": 205,
-    "url": "https://www.meetup.com/Melbourne-Apache-Airflow-Meetup/"
-  },
-  {
-    "city": "Paris",
-    "country": "France",
-    "date": "",
-    "members": 1299,
-    "url": "https://www.meetup.com/Paris-Apache-Airflow-Meetup/"
-  },
-  {
-    "city": "Portland",
-    "country": "USA",
-    "date": "",
-    "members": 142,
-    "url": "https://www.meetup.com/Portland-Apache-Airflow-Meetup/"
+    "members": 395,
+    "url": "https://www.meetup.com/sao-paulo-apache-airflow-meetup-group/"
   },
   {
     "city": "Tokyo",
@@ -75,34 +124,6 @@
     "date": "",
     "members": 210,
     "url": "https://www.meetup.com/Tokyo-Apache-Airflow-incubating-Meetup/"
-  },
-  {
-    "city": "Bangalore",
-    "country": "India",
-    "date": "",
-    "members": 1467,
-    "url": "https://www.meetup.com/Bangalore-Apache-Airflow-Meetup/"
-  },
-  {
-    "city": "Charlotte",
-    "country": "USA",
-    "date": "",
-    "members": 69,
-    "url": "https://www.meetup.com/charlotte-apache-airflow-meetup/"
-  },
-  {
-    "city": "Hyderabad",
-    "country": "India",
-    "date": "",
-    "members": 100,
-    "url": "https://www.meetup.com/hyderabad-apache-airflow-meetup-group/"
-  },
-  {
-    "city": "Prague",
-    "country": "Czech Republic",
-    "date": "",
-    "members": 51,
-    "url": "https://www.meetup.com/prague-airflow-meetup-group/"
   },
   {
     "city": "Toronto",

--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -112,7 +112,7 @@
     "url": "https://www.meetup.com/dc-area-apache-airflow-meetup/"
   },
   {
-    "city": "São Paulo",
+    "city": "S\u00e3o Paulo",
     "country": "Brazil",
     "date": "",
     "members": 395,


### PR DESCRIPTION
Add 3 Meetup Groups to the Airflow site: Lisbon, Seoul, and São Paulo. Also alphabetized them.