### PR TITLE
Add Scarf Pixel to Airflow RTD Theme

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
@@ -317,6 +317,9 @@
         })();
     </script>
     <!-- End Matomo Code -->
+    <!-- Scarf Telemetry Pixel -->
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
+    <!-- End Scarf Telemetry Pixel -->
     {%- block extrahead %}
 
     {% endblock %}


### PR DESCRIPTION
Similar to https://github.com/apache/superset/pull/25065 and https://github.com/apache/airflow/pull/39510 but this one doesn't need to wait for the VOTE since this adds a simple transparent tracking pixel. More detail in https://docs.scarf.sh/web-traffic/

All of this data will be available in Scarf, creds for which are shared to 1password for PMC members, and can be reported periodically in things like Town Hall or newsletters.