### PR TITLE
Add `astronomer-cosmos` in Airflow ecosystem project list

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -91,6 +91,8 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Airflow TM1 Provider](https://github.com/KnowledgeSeed/airflow-providers-tm1) - Provides Hook and Operators to simplify connecting to the IBM Cognos TM1 / Planning Analytics database over REST API.
 
+[Astronomer Cosmos](https://github.com/astronomer/astronomer-cosmos) - Run your dbt Core projects as Apache Airflow DAGs and Task Groups with a few lines of code.
+
 &nbsp;
 
 ## Async Providers


### PR DESCRIPTION
`astronomer-cosmos` is an open-source project run dbt Core projects as Apache Airflow DAGs and Task Groups.

- GH Repo: https://github.com/astronomer/astronomer-cosmos
- Docs: https://astronomer.github.io/astronomer-cosmos/