### PR TITLE
Switch to public runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    runs-on: ["self-hosted", "asf-runner"]
+    runs-on: ["ubuntu-22.04"]
     steps:
       # Based on https://github.com/actions/runner-images/issues/2840
       - name: 🪓 Remove some stuff we don't need


### PR DESCRIPTION
https://github.com/apache/airflow-site/actions/runs/10386270974 This request was automatically failed because there were no enabled runners online to process the request for more than 1 days. Based on https://github.com/apache/airflow-site/actions/runners we only have ARM runners for ASF-hosted so far now falling back to public runners


<img width="1328" alt="image" src="https://github.com/user-attachments/assets/a65aaade-b2a1-44d1-9f99-9939e251a280">

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/c831255a-b36f-4a7a-838a-b2bab6b8d168">
