### PR TITLE
Fix helm chart 1.15.0 release date

### DIFF
--- a/docs-archive/helm-chart/1.15.0/release_notes.html
+++ b/docs-archive/helm-chart/1.15.0/release_notes.html
@@ -42,9 +42,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -83,38 +83,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -158,38 +158,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -200,8 +200,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -350,7 +350,7 @@
 <ul class="current">
 <li class="toctree-l1"><a class="reference internal" href="parameters-ref.html">Parameters</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="#">Release Notes</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="#airflow-helm-chart-1-15-0-2022-07-24">Airflow Helm Chart 1.15.0 (2022-07-24)</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="#airflow-helm-chart-1-15-0-2024-07-24">Airflow Helm Chart 1.15.0 (2024-07-24)</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#significant-changes">Significant Changes</a><ul>
 <li class="toctree-l4"><a class="reference internal" href="#default-airflow-image-is-updated-to-2-9-3-40816">Default Airflow image is updated to <code class="docutils literal notranslate"><span class="pre">2.9.3</span></code> (#40816)</a></li>
 <li class="toctree-l4"><a class="reference internal" href="#default-pgbouncer-exporter-image-has-been-updated-40318">Default PgBouncer Exporter image has been updated (#40318)</a></li>
@@ -644,10 +644,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -716,7 +716,7 @@
 <ul class="current">
 <li class="toctree-l1"><a class="reference internal" href="parameters-ref.html">Parameters</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="#">Release Notes</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="#airflow-helm-chart-1-15-0-2022-07-24">Airflow Helm Chart 1.15.0 (2022-07-24)</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="#airflow-helm-chart-1-15-0-2024-07-24">Airflow Helm Chart 1.15.0 (2024-07-24)</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#significant-changes">Significant Changes</a><ul>
 <li class="toctree-l4"><a class="reference internal" href="#default-airflow-image-is-updated-to-2-9-3-40816">Default Airflow image is updated to <code class="docutils literal notranslate"><span class="pre">2.9.3</span></code> (#40816)</a></li>
 <li class="toctree-l4"><a class="reference internal" href="#default-pgbouncer-exporter-image-has-been-updated-40318">Default PgBouncer Exporter image has been updated (#40318)</a></li>
@@ -1007,15 +1007,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -1023,20 +1023,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -1046,7 +1046,7 @@
 <div class="contents local topic" id="apache-airflow-helm-chart-releases">
 <p class="topic-title">Apache Airflow Helm Chart Releases</p>
 <ul class="simple">
-<li><p><a class="reference internal" href="#airflow-helm-chart-1-15-0-2022-07-24" id="id86">Airflow Helm Chart 1.15.0 (2022-07-24)</a></p></li>
+<li><p><a class="reference internal" href="#airflow-helm-chart-1-15-0-2024-07-24" id="id86">Airflow Helm Chart 1.15.0 (2024-07-24)</a></p></li>
 <li><p><a class="reference internal" href="#airflow-helm-chart-1-14-0-2024-06-18" id="id87">Airflow Helm Chart 1.14.0 (2024-06-18)</a></p></li>
 <li><p><a class="reference internal" href="#airflow-helm-chart-1-13-1-2024-03-25" id="id88">Airflow Helm Chart 1.13.1 (2024-03-25)</a></p></li>
 <li><p><a class="reference internal" href="#airflow-helm-chart-1-13-0-2024-03-05" id="id89">Airflow Helm Chart 1.13.0 (2024-03-05)</a></p></li>
@@ -1065,8 +1065,8 @@
 </ul>
 </div>
 <p>Run <code class="docutils literal notranslate"><span class="pre">helm</span> <span class="pre">repo</span> <span class="pre">update</span></code> before upgrading the chart to the latest version.</p>
-<div class="section" id="airflow-helm-chart-1-15-0-2022-07-24">
-<h2><a class="toc-backref" href="#id86">Airflow Helm Chart 1.15.0 (2022-07-24)</a><a class="headerlink" href="#airflow-helm-chart-1-15-0-2022-07-24" title="Permalink to this heading">¶</a></h2>
+<div class="section" id="airflow-helm-chart-1-15-0-2024-07-24">
+<h2><a class="toc-backref" href="#id86">Airflow Helm Chart 1.15.0 (2024-07-24)</a><a class="headerlink" href="#airflow-helm-chart-1-15-0-2024-07-24" title="Permalink to this heading">¶</a></h2>
 <div class="section" id="significant-changes">
 <h3>Significant Changes<a class="headerlink" href="#significant-changes" title="Permalink to this heading">¶</a></h3>
 <div class="section" id="default-airflow-image-is-updated-to-2-9-3-40816">
@@ -2245,17 +2245,17 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
 <li><a class="reference internal" href="#">Release Notes</a><ul>
-<li><a class="reference internal" href="#airflow-helm-chart-1-15-0-2022-07-24">Airflow Helm Chart 1.15.0 (2022-07-24)</a><ul>
+<li><a class="reference internal" href="#airflow-helm-chart-1-15-0-2024-07-24">Airflow Helm Chart 1.15.0 (2024-07-24)</a><ul>
 <li><a class="reference internal" href="#significant-changes">Significant Changes</a><ul>
 <li><a class="reference internal" href="#default-airflow-image-is-updated-to-2-9-3-40816">Default Airflow image is updated to <code class="docutils literal notranslate"><span class="pre">2.9.3</span></code> (#40816)</a></li>
 <li><a class="reference internal" href="#default-pgbouncer-exporter-image-has-been-updated-40318">Default PgBouncer Exporter image has been updated (#40318)</a></li>
@@ -2479,12 +2479,8 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -2492,10 +2488,14 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/helm-chart/release_notes.rst" rel="nofollow">
 
@@ -2508,12 +2508,12 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -2588,7 +2588,7 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -2598,7 +2598,7 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -2621,7 +2621,7 @@ and <code class="docutils literal notranslate"><span class="pre">tolerations</sp
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>


### PR DESCRIPTION
Version 1.15.0 was released on `2024-07-24` not on `2022-07-24`

https://github.com/apache/airflow/pull/41006 fixed it in the source but since doc were already generated we need regenerate the doc build for the site with manual fix.