### PR TITLE
Add entry of Airflow OpenTelemetry Provider in /ecosystem

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -93,6 +93,8 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Astronomer Cosmos](https://github.com/astronomer/astronomer-cosmos) - Run your dbt Core projects as Apache Airflow DAGs and Task Groups with a few lines of code.
 
+[Airflow OpenTelemetry Provider](https://github.com/howardyoo/airflow_otel_provider) - Provides Hook and EventListener which will generate traces, metrics, and logs in [OpenTelemetry](https://opentelemetry.io/) for your DAG runs.
+
 &nbsp;
 
 ## Async Providers


### PR DESCRIPTION
# Overview of the PR
The proposed change is to add a new entry to specify of the third party provider related to OpenTelemetry that provides hook and event listener to generate traces, metrics, and logs during the DAG run.

The provider is intended to be used by users who need to produce their own DAG specific spans, metrics, and logs, that will work in conjunction with Airflow's OTEL support, as well as independently if the OTEL feature is not available. Please refer to https://github.com/howardyoo/airflow_otel_provider for more information.