### PR TITLE
Add do_xcom_push in EcsRunTaskOperator

### DIFF
--- a/docs-archive/apache-airflow-providers-amazon/9.1.0/_api/airflow/providers/amazon/aws/operators/ecs/index.html
+++ b/docs-archive/apache-airflow-providers-amazon/9.1.0/_api/airflow/providers/amazon/aws/operators/ecs/index.html
@@ -916,6 +916,8 @@ if not set then the default waiter value will be used.</p></li>
 <li><p><strong>deferrable</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.13)"><em>bool</em></a>) – If True, the operator will wait asynchronously for the job to complete.
 This implies waiting for completion. This mode requires aiobotocore module to be installed.
 (default: False)</p></li>
+<li><p><strong>do_xcom_push</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.13)"><em>bool</em></a>) – If True, the operator will push the ECS task ARN to XCom with key 'ecs_task_arn'. Additionally, if logs are fetched, the last log message will be pushed to XCom with the key 'return_value'. (default: False)
+(default: False)</p></li>
 </ul>
 </dd>
 </dl>


### PR DESCRIPTION
Adding documentation for the do_xcom_push parameter in the EcsRunTaskOperator. This parameter pushes the ECS task ARN into XCom, and if AWS CloudWatch logs are fetched, it also adds the last log message to XCom with the key 'return_value'