### PR TITLE
[BREAKING CHANGE] Update link tag for compatibility with Sphinx v7

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
@@ -223,7 +223,7 @@
 {%- endmacro %}
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1) }}" type="text/css" />
 
     {%- for css in css_files %}
         {%- if css|attr("filename") %}


### PR DESCRIPTION
This is a required change for upgrading Sphinx to version 7+ (see: https://github.com/readthedocs/sphinx_rtd_theme/issues/1465).
It won't work with older versions.