### PR TITLE
Remove Google Analytics from last few pages of Airflow Website

### DIFF
--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/databricks/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/databricks/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.hooks.databricks_base" href="../databricks_base/index.html" />
             <link rel="prev" title="airflow.providers.databricks.hooks" href="../index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/databricks_base/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/databricks_base/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.hooks.databricks_sql" href="../databricks_sql/index.html" />
             <link rel="prev" title="airflow.providers.databricks.hooks.databricks" href="../databricks/index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/databricks_sql/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/databricks_sql/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.operators" href="../../operators/index.html" />
             <link rel="prev" title="airflow.providers.databricks.hooks.databricks_base" href="../databricks_base/index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/hooks/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.hooks.databricks" href="databricks/index.html" />
             <link rel="prev" title="airflow.providers.databricks" href="../index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.hooks" href="hooks/index.html" />
             <link rel="prev" title="DatabricksSubmitRunOperator" href="../../../../operators/submit_run.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/databricks/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/databricks/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.operators.databricks_repos" href="../databricks_repos/index.html" />
             <link rel="prev" title="airflow.providers.databricks.operators" href="../index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/databricks_repos/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/databricks_repos/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.operators.databricks_sql" href="../databricks_sql/index.html" />
             <link rel="prev" title="airflow.providers.databricks.operators.databricks" href="../databricks/index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/databricks_sql/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/databricks_sql/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../../search.html" />
             <link rel="next" title="Installing from sources" href="../../../../../../installing-providers-from-sources.html" />
             <link rel="prev" title="airflow.providers.databricks.operators.databricks_repos" href="../databricks_repos/index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_api/airflow/providers/databricks/operators/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../../../../../search.html" />
             <link rel="next" title="airflow.providers.databricks.operators.databricks" href="databricks/index.html" />
             <link rel="prev" title="airflow.providers.databricks.hooks.databricks_sql" href="../hooks/databricks_sql/index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/example_dags/example_databricks.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/example_dags/example_databricks.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/hooks/databricks.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/hooks/databricks.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/hooks/databricks_base.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/hooks/databricks_base.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/hooks/databricks_sql.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/hooks/databricks_sql.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/operators/databricks.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/operators/databricks.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/operators/databricks_repos.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/operators/databricks_repos.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/operators/databricks_sql.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/airflow/providers/databricks/operators/databricks_sql.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../../../../../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../../../../../genindex.html" />
             <link rel="search" title="Search" href="../../../../../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/_modules/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/_modules/index.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="../_static/pin_32.png"/>
             <link rel="index" title="Index" href="../genindex.html" />
             <link rel="search" title="Search" href="../search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 </head><body class="td-section">

--- a/docs/apache-airflow-providers-databricks/2.6.0/commits.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/commits.html
@@ -20,13 +20,6 @@
             <link rel="index" title="Index" href="genindex.html" />
             <link rel="search" title="Search" href="search.html" />
             <link rel="prev" title="Installing from sources" href="installing-providers-from-sources.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/commits.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/connections/databricks.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/connections/databricks.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="Databricks Operators" href="../operators/index.html" />
             <link rel="prev" title="apache-airflow-providers-databricks" href="../index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/connections/databricks.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/genindex.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/genindex.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="_static/pin_32.png"/>
             <link rel="index" title="Index" href="#" />
             <link rel="search" title="Search" href="search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/genindex.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/index.html
@@ -20,13 +20,6 @@
             <link rel="index" title="Index" href="genindex.html" />
             <link rel="search" title="Search" href="search.html" />
             <link rel="next" title="Databricks Connection" href="connections/databricks.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/index.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/installing-providers-from-sources.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/installing-providers-from-sources.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="search.html" />
             <link rel="next" title="Package apache-airflow-providers-databricks" href="commits.html" />
             <link rel="prev" title="airflow.providers.databricks.operators.databricks_sql" href="_api/airflow/providers/databricks/operators/databricks_sql/index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/installing-providers-from-sources.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/copy_into.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/copy_into.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksReposCreateOperator" href="repos_create.html" />
             <link rel="prev" title="Databricks Operators" href="index.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/copy_into.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/index.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/index.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksCopyIntoOperator" href="copy_into.html" />
             <link rel="prev" title="Databricks Connection" href="../connections/databricks.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/index.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/repos_create.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/repos_create.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksReposDeleteOperator" href="repos_delete.html" />
             <link rel="prev" title="DatabricksCopyIntoOperator" href="copy_into.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/repos_create.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/repos_delete.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/repos_delete.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksReposUpdateOperator" href="repos_update.html" />
             <link rel="prev" title="DatabricksReposCreateOperator" href="repos_create.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/repos_delete.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/repos_update.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/repos_update.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksRunNowOperator" href="run_now.html" />
             <link rel="prev" title="DatabricksReposDeleteOperator" href="repos_delete.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/repos_update.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/run_now.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/run_now.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksSqlOperator" href="sql.html" />
             <link rel="prev" title="DatabricksReposUpdateOperator" href="repos_update.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/run_now.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/sql.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/sql.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="DatabricksSubmitRunOperator" href="submit_run.html" />
             <link rel="prev" title="DatabricksRunNowOperator" href="run_now.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/sql.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/operators/submit_run.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/operators/submit_run.html
@@ -21,13 +21,6 @@
             <link rel="search" title="Search" href="../search.html" />
             <link rel="next" title="airflow.providers.databricks" href="../_api/airflow/providers/databricks/index.html" />
             <link rel="prev" title="DatabricksSqlOperator" href="sql.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
     
 <link rel="canonical" href="https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/operators/submit_run.html" />

--- a/docs/apache-airflow-providers-databricks/2.6.0/py-modindex.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/py-modindex.html
@@ -19,13 +19,6 @@
             <link rel="shortcut icon" href="_static/pin_32.png"/>
             <link rel="index" title="Index" href="genindex.html" />
             <link rel="search" title="Search" href="search.html" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
 
 
     

--- a/docs/apache-airflow-providers-databricks/2.6.0/search.html
+++ b/docs/apache-airflow-providers-databricks/2.6.0/search.html
@@ -19,14 +19,6 @@
             <link rel="shortcut icon" href="_static/pin_32.png"/>
             <link rel="index" title="Index" href="genindex.html" />
             <link rel="search" title="Search" href="#" />
-    <script type="application/javascript">
-        var doNotTrack = false;
-        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-        ga('create', 'UA-140539454-1', 'auto');
-        ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
-  <script src="searchindex.js" defer></script>
   
 
     


### PR DESCRIPTION
Hi Airflow team,

We appreciate that you have migrated from **_Google Analytics_** to **_Matomo_**, but there seems to be a few pages left (32) that are still using GA. Please could you remove them?

Thanks

Niall