### PR TITLE
Fix meta charset tag to properly set utf-8 encoding

### DIFF
--- a/landing-pages/site/config.toml
+++ b/landing-pages/site/config.toml
@@ -66,6 +66,7 @@ weight = 1
 # Everything below this are Site Params
 
 [params]
+charset = "utf-8"
 copyright = "The Apache Software Foundation"
 privacy_policy = "https://policies.google.com/privacy"
 blocktype = ["use-case", "testimonial"]

--- a/landing-pages/site/layouts/partials/head.html
+++ b/landing-pages/site/layouts/partials/head.html
@@ -17,7 +17,7 @@
  under the License.
 */}}
 
-meta charset="utf-8">
+<meta charset="{{ .Site.Params.charset }}">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
 {{ if eq (getenv "HUGO_ENV") "production" }}


### PR DESCRIPTION
## Description
<img width="1340" alt="screenshot" src="https://github.com/user-attachments/assets/c5645223-6ca6-44ee-b563-6590910e6273" />.  
- Fix character encoding issues by adding proper utf-8 meta charset tag in head.html.

## Changes
- Add charset parameter in config.toml
- Set utf-8 encoding in head.html using meta charset tag