### PR TITLE
Adding information about a new tool integrating with Airflow

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -141,6 +141,8 @@ Apache Airflow releases the [Official Apache Airflow Community Chart](https://ai
 
 [airflow-maintenance-dags](https://github.com/teamclairvoyant/airflow-maintenance-dags) - [Clairvoyant](https://clairvoyantsoft.com/) has a repo of Airflow DAGs that operator on Airflow itself, clearing out various bits of the backing metadata store.
 
+[airflow-parse-bench](https://github.com/AlvaroCavalcante/airflow-parse-bench) - A Python tool (CLI) to measure and compare the parse time of your DAGs in your local machine.
+
 [AirflowK8sDebugger](https://github.com/Javier162380/AirflowKuberentesDebugger) - A library for generate k8s pod yaml templates from an Airflow dag using the KubernetesPodOperator.
 
 [Airflow Ditto](https://github.com/angadsingh/airflow-ditto) - An extensible framework to do transformations to an Airflow DAG and convert it into another DAG which is flow-isomorphic with the original DAG, to be able to run it on different environments (e.g. on different clouds, or even different container frameworks - Apache Spark on YARN vs Kubernetes). Comes with out-of-the-box support for EMR-to-HDInsight-DAG transforms.


### PR DESCRIPTION
Hi everyone!

A few days ago, I opened a discussion on the Airflow repo to share a Python tool called [airflow-parse-bench](https://github.com/AlvaroCavalcante/airflow-parse-bench). I developed this tool to help engineers quickly and easily measure, compare, and reduce the parse time of their DAGs.

In the [discussion](https://github.com/apache/airflow/discussions/46578), @potiuk gave me the idea of opening a PR to add this tool to this Ecosystem page!

For this reason, I'd like to merge this simple modification to add information about this useful tool for the Airflow environment!