### PR TITLE
Update member counts and remove Amsterdam meetup

### DIFF
--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -1,156 +1,142 @@
 [
   {
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "date": "",
-    "members": 417,
-    "url": "https://www.meetup.com/Amsterdam-Airflow-meetup/"
-  },
-  {
     "city": "Bangalore",
     "country": "India",
     "date": "",
-    "members": 1717,
+    "members": 1802,
     "url": "https://www.meetup.com/Bangalore-Apache-Airflow-Meetup/"
   },
   {
     "city": "Charlotte",
     "country": "USA",
     "date": "",
-    "members": 73,
+    "members": 78,
     "url": "https://www.meetup.com/charlotte-apache-airflow-meetup/"
   },
   {
     "city": "Chicago",
     "country": "USA",
     "date": "",
-    "members": 118,
+    "members": 192,
     "url": "https://www.meetup.com/chicago-apache-airflow-meetup-group/"
   },
   {
     "city": "Hyderabad",
     "country": "India",
     "date": "",
-    "members": 510,
+    "members": 545,
     "url": "https://www.meetup.com/hyderabad-apache-airflow-meetup-group/"
   },
   {
     "city": "Seoul",
     "country": "Korea",
     "date": "",
-    "members": 67,
+    "members": 236,
     "url": "https://www.meetup.com/apache-airflow-users-korea/"
   },
   {
     "city": "Lisbon",
     "country": "Portugal",
     "date": "",
-    "members": 13,
+    "members": 117,
     "url": "https://www.meetup.com/lisbon-apache-airflow-meetup-group/"
   },
   {
     "city": "London",
     "country": "United Kingdom",
     "date": "",
-    "members": 1163,
+    "members": 1192,
     "url": "https://www.meetup.com/London-Apache-Airflow-Meetup/"
   },
   {
     "city": "Melbourne",
     "country": "Australia",
     "date": "",
-    "members": 209,
+    "members": 213,
     "url": "https://www.meetup.com/Melbourne-Apache-Airflow-Meetup/"
   },
   {
     "city": "New York",
     "country": "USA",
     "date": "",
-    "members": 1875,
+    "members": 2090,
     "url": "https://www.meetup.com/NYC-Apache-Airflow-Meetup/"
   },
   {
     "city": "Paris",
     "country": "France",
     "date": "",
-    "members": 1306,
+    "members": 1337,
     "url": "https://www.meetup.com/Paris-Apache-Airflow-Meetup/"
   },
   {
     "city": "Portland",
     "country": "USA",
     "date": "",
-    "members": 143,
+    "members": 141,
     "url": "https://www.meetup.com/Portland-Apache-Airflow-Meetup/"
   },
   {
     "city": "Prague",
     "country": "Czech Republic",
     "date": "",
-    "members": 115,
+    "members": 119,
     "url": "https://www.meetup.com/prague-airflow-meetup-group/"
   },
   {
     "city": "Tel Aviv-Yafo",
     "country": "Israel",
     "date": "",
-    "members": 1013,
+    "members": 1022,
     "url": "https://www.meetup.com/tel-aviv-apache-airflow-meetup/"
   },
   {
     "city": "San Francisco Bay Area",
     "country": "USA",
     "date": "",
-    "members": 2178,
+    "members": 2280,
     "url": "https://www.meetup.com/Bay-Area-Apache-Airflow-Incubating-Meetup/"
   },
   {
     "city": "Washington D.C.",
     "country": "USA",
     "date": "",
-    "members": 136,
+    "members": 151,
     "url": "https://www.meetup.com/dc-area-apache-airflow-meetup/"
   },
   {
     "city": "S\u00e3o Paulo",
     "country": "Brazil",
     "date": "",
-    "members": 395,
+    "members": 438,
     "url": "https://www.meetup.com/sao-paulo-apache-airflow-meetup-group/"
   },
   {
     "city": "Tokyo",
     "country": "Japan",
     "date": "",
-    "members": 210,
+    "members": 213,
     "url": "https://www.meetup.com/Tokyo-Apache-Airflow-incubating-Meetup/"
   },
   {
     "city": "Toronto",
     "country": "Canada",
     "date": "",
-    "members": 196,
+    "members": 225,
     "url": "https://www.meetup.com/toronto-apache-airflow-meetup/"
-  },
-  {
-    "city": "Seoul",
-    "country": "Korea",
-    "date": "",
-    "members": 52,
-    "url": "https://www.meetup.com/apache-airflow-users-korea/"
   },
   {
     "city": "Taipei",
     "country": "Taiwan",
     "date": "",
-    "members": 30,
+    "members": 34,
     "url": "https://www.meetup.com/taipei-py/"
   },
   {
     "city": "Warsaw",
     "country": "Poland",
     "date": "",
-    "members": 127,
+    "members": 236,
     "url": "https://www.meetup.com/pl-PL/warsaw-apache-airflow-meetup-group/"
   }
 ]


### PR DESCRIPTION
- Updated member counts for all meetups with the latest data.
- Removed the Amsterdam meetup because its URL returned a "Group not found" error and no alternative meetup was identified.
- Removed duplicate entries for the Seoul meetup, keeping only a single instance.