### PR TITLE
Add Vancouver as a Meetup location

### DIFF
--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -133,6 +133,13 @@
     "url": "https://www.meetup.com/taipei-py/"
   },
   {
+    "city": "Vancouver",
+    "country": "Canada",
+    "date": "",
+    "members": 192,
+    "url": "https://www.meetup.com/vancouver-apache-airflow-meetup/"
+  },
+  {
     "city": "Warsaw",
     "country": "Poland",
     "date": "",


### PR DESCRIPTION
Vancouver hosted our first meetup last week and it was a great success! Let's add it to the website along with the other cities that host meetups.