### PR TITLE
Add U+00AE (Registered Trademark) to unicode-range in Rubik.css

### DIFF
--- a/landing-pages/site/static/external/css/Rubik.css
+++ b/landing-pages/site/static/external/css/Rubik.css
@@ -50,5 +50,5 @@
   font-weight: 500;
   font-display: swap;
   src: url(/external/fonts/Rubik-normal.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD, U+00AE;
 }


### PR DESCRIPTION
This PR aims to resolve the issue described in #1129 , 

where U+00AE (Registered Trademark, ®) may have been missing from the unicode-range, 
potentially causing the character to render incorrectly. 

The `U+00AE` has now been added to the range to address this.