### PR TITLE
Add the description for survey in 2023 and 2024

### DIFF
--- a/landing-pages/site/content/en/blog/airflow-survey-2023/index.md
+++ b/landing-pages/site/content/en/blog/airflow-survey-2023/index.md
@@ -3,6 +3,7 @@ title: "Airflow Survey 2023"
 tags: ["community", "survey", "users"]
 date: "2023-09-21"
 author: "Michael Robinson"
+description: "2023 saw rapid adoption of Airflow 2, and continued growth of the community. This annual survey helps us understand how people are using Airflow, and where we can best focus our efforts going forward."
 github: "merobi-hub"
 ---
 

--- a/landing-pages/site/content/en/blog/airflow-survey-2023/index.md
+++ b/landing-pages/site/content/en/blog/airflow-survey-2023/index.md
@@ -3,7 +3,7 @@ title: "Airflow Survey 2023"
 tags: ["community", "survey", "users"]
 date: "2023-09-21"
 author: "Michael Robinson"
-description: "2023 saw rapid adoption of Airflow 2, and continued growth of the community. This annual survey helps us understand how people are using Airflow, and where we can best focus our efforts going forward."
+description: "Airflow 2 has seen rapid adoption, accompanied by continuous community growth. This annual survey helps us understand how people use Airflow and where we can best focus our efforts as we advance."
 github: "merobi-hub"
 ---
 

--- a/landing-pages/site/content/en/blog/airflow-survey-2024/index.md
+++ b/landing-pages/site/content/en/blog/airflow-survey-2024/index.md
@@ -6,6 +6,7 @@ date: "2025-02-27"
 author: "Ankit Chaurasia"
 github: "sunank200"
 linkedin: "sunank200"
+description: "With more than 5,250 responses from 116 countries, this is the largest data engineering survey to date. Conducted annually, it offers valuable insights into Airflow usage and helps guide our future efforts."
 menu:
   main:
     weight: 31


### PR DESCRIPTION
- Add the description for the survey in 2023 and 2024 as per @ephraimbuddy request.

After change:
<img width="1708" alt="Screenshot 2025-02-27 at 6 52 06 PM" src="https://github.com/user-attachments/assets/90b06ecd-6411-4f50-97be-c1fa8053970b" />
