### PR TITLE
Replace AIP-48 label with area:data-aware-scheduling

### DIFF
--- a/docs-archive/apache-airflow/2.10.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.10.0/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1464,10 +1464,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2645,15 +2645,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2661,20 +2661,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -6077,7 +6077,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id106">
 <h3>New Features<a class="headerlink" href="#id106" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16693,12 +16693,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17726,12 +17726,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17739,10 +17735,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17755,12 +17755,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17835,7 +17835,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17845,7 +17845,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -17868,7 +17868,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.10.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.10.1/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1473,10 +1473,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2663,15 +2663,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2679,20 +2679,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -6143,7 +6143,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id110">
 <h3>New Features<a class="headerlink" href="#id110" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16759,12 +16759,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17801,12 +17801,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17814,10 +17810,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17830,12 +17830,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17910,7 +17910,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17920,7 +17920,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -17943,7 +17943,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.10.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.10.2/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1482,10 +1482,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2681,15 +2681,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2697,20 +2697,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -6203,7 +6203,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id114">
 <h3>New Features<a class="headerlink" href="#id114" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16819,12 +16819,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17870,12 +17870,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17883,10 +17879,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17899,12 +17899,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17979,7 +17979,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17989,7 +17989,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -18012,7 +18012,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.10.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.10.3/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1491,10 +1491,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2699,15 +2699,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2715,20 +2715,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -6290,7 +6290,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id118">
 <h3>New Features<a class="headerlink" href="#id118" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16906,12 +16906,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17966,12 +17966,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17979,10 +17975,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17995,12 +17995,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -18075,7 +18075,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -18085,7 +18085,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -18108,7 +18108,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.10.4/release_notes.html
+++ b/docs-archive/apache-airflow/2.10.4/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1504,10 +1504,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2725,15 +2725,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2741,20 +2741,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -6372,7 +6372,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id122">
 <h3>New Features<a class="headerlink" href="#id122" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16988,12 +16988,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -18061,12 +18061,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -18074,10 +18070,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -18090,12 +18090,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -18170,7 +18170,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -18180,7 +18180,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -18203,7 +18203,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.10.5/release_notes.html
+++ b/docs-archive/apache-airflow/2.10.5/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1513,10 +1513,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2743,15 +2743,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2759,20 +2759,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <section id="release-notes">
@@ -6438,7 +6438,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <section id="id125">
 <h3>New Features<a class="headerlink" href="#id125" title="Link to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -17001,12 +17001,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -18083,12 +18083,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -18096,10 +18092,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -18112,12 +18112,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -18192,7 +18192,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -18202,7 +18202,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -18225,7 +18225,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.4.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.4.0/release_notes.html
@@ -2272,7 +2272,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="new-features">
 <h3>New Features<a class="headerlink" href="#new-features" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.4.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.4.1/release_notes.html
@@ -2329,7 +2329,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="new-features">
 <h3>New Features<a class="headerlink" href="#new-features" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.4.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.4.2/release_notes.html
@@ -2418,7 +2418,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="new-features">
 <h3>New Features<a class="headerlink" href="#new-features" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.4.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.4.3/release_notes.html
@@ -2492,7 +2492,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="new-features">
 <h3>New Features<a class="headerlink" href="#new-features" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.5.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.5.0/release_notes.html
@@ -2746,7 +2746,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id13">
 <h3>New Features<a class="headerlink" href="#id13" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.5.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.5.1/release_notes.html
@@ -2860,7 +2860,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id17">
 <h3>New Features<a class="headerlink" href="#id17" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.5.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.5.2/release_notes.html
@@ -2993,7 +2993,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id21">
 <h3>New Features<a class="headerlink" href="#id21" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.5.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.5.3/release_notes.html
@@ -3050,7 +3050,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id25">
 <h3>New Features<a class="headerlink" href="#id25" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.6.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.6.0/release_notes.html
@@ -3403,7 +3403,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id31">
 <h3>New Features<a class="headerlink" href="#id31" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.6.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.6.1/release_notes.html
@@ -3505,7 +3505,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id35">
 <h3>New Features<a class="headerlink" href="#id35" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.6.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.6.2/release_notes.html
@@ -3610,7 +3610,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id39">
 <h3>New Features<a class="headerlink" href="#id39" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.6.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.6.3/release_notes.html
@@ -3699,7 +3699,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id43">
 <h3>New Features<a class="headerlink" href="#id43" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.7.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.7.0/release_notes.html
@@ -4095,7 +4095,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id49">
 <h3>New Features<a class="headerlink" href="#id49" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>

--- a/docs-archive/apache-airflow/2.7.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.7.1/release_notes.html
@@ -46,9 +46,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -87,38 +87,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -162,38 +162,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -204,8 +204,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1320,10 +1320,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2355,15 +2355,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2371,20 +2371,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -4222,7 +4222,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id53">
 <h3>New Features<a class="headerlink" href="#id53" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -14838,12 +14838,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -15730,12 +15730,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -15743,10 +15739,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -15759,12 +15759,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -15839,7 +15839,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -15849,7 +15849,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -15872,7 +15872,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.7.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.7.2/release_notes.html
@@ -46,9 +46,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -87,38 +87,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -162,38 +162,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -204,8 +204,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1329,10 +1329,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2373,15 +2373,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2389,20 +2389,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -4359,7 +4359,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id57">
 <h3>New Features<a class="headerlink" href="#id57" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -14975,12 +14975,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -15876,12 +15876,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -15889,10 +15885,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -15905,12 +15905,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -15985,7 +15985,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -15995,7 +15995,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16018,7 +16018,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.7.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.7.3/release_notes.html
@@ -46,9 +46,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -87,38 +87,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -162,38 +162,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -204,8 +204,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1338,10 +1338,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2391,15 +2391,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2407,20 +2407,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -4445,7 +4445,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id61">
 <h3>New Features<a class="headerlink" href="#id61" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -15061,12 +15061,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -15971,12 +15971,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -15984,10 +15980,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -16000,12 +16000,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -16080,7 +16080,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -16090,7 +16090,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16113,7 +16113,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.8.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.8.0/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1351,10 +1351,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2415,15 +2415,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2431,20 +2431,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -4676,7 +4676,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id66">
 <h3>New Features<a class="headerlink" href="#id66" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -15293,12 +15293,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -16214,12 +16214,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -16227,10 +16223,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -16243,12 +16243,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -16323,7 +16323,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -16333,7 +16333,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16356,7 +16356,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.8.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.8.1/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1364,10 +1364,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2441,15 +2441,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2457,20 +2457,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -4858,7 +4858,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id70">
 <h3>New Features<a class="headerlink" href="#id70" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -15475,12 +15475,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -16409,12 +16409,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -16422,10 +16418,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -16438,12 +16438,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -16518,7 +16518,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -16528,7 +16528,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16551,7 +16551,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.8.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.8.2/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1376,10 +1376,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2465,15 +2465,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2481,20 +2481,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5009,7 +5009,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id74">
 <h3>New Features<a class="headerlink" href="#id74" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -15626,12 +15626,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -16572,12 +16572,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -16585,10 +16581,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -16601,12 +16601,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -16681,7 +16681,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -16691,7 +16691,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16714,7 +16714,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.8.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.8.3/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1386,10 +1386,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2485,15 +2485,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2501,20 +2501,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5072,7 +5072,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id78">
 <h3>New Features<a class="headerlink" href="#id78" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -15689,12 +15689,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -16645,12 +16645,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -16658,10 +16654,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -16674,12 +16674,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -16754,7 +16754,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -16764,7 +16764,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16787,7 +16787,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.8.4/release_notes.html
+++ b/docs-archive/apache-airflow/2.8.4/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1395,10 +1395,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2503,15 +2503,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2519,20 +2519,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5125,7 +5125,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id82">
 <h3>New Features<a class="headerlink" href="#id82" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -15742,12 +15742,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -16707,12 +16707,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -16720,10 +16716,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -16736,12 +16736,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -16816,7 +16816,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -16826,7 +16826,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -16849,7 +16849,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.9.0/release_notes.html
+++ b/docs-archive/apache-airflow/2.9.0/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use-cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use-cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1414,10 +1414,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2541,15 +2541,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2557,20 +2557,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5468,7 +5468,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id88">
 <h3>New Features<a class="headerlink" href="#id88" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16085,12 +16085,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17069,12 +17069,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17082,10 +17078,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17098,12 +17098,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17178,7 +17178,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17188,7 +17188,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -17211,7 +17211,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.9.1/release_notes.html
+++ b/docs-archive/apache-airflow/2.9.1/release_notes.html
@@ -48,9 +48,9 @@
     <!-- Scarf Telemetry Pixel -->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7265a3c4-a6dd-4933-ba8b-9e3c13903c60" />
     <!-- End Scarf Telemetry Pixel -->
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -89,38 +89,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -164,38 +164,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -206,8 +206,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1425,10 +1425,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2563,15 +2563,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2579,20 +2579,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5566,7 +5566,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id92">
 <h3>New Features<a class="headerlink" href="#id92" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16183,12 +16183,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17178,12 +17178,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17191,10 +17187,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17207,12 +17207,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17287,7 +17287,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17297,7 +17297,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -17320,7 +17320,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.9.2/release_notes.html
+++ b/docs-archive/apache-airflow/2.9.2/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1430,10 +1430,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2577,15 +2577,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2593,20 +2593,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5645,7 +5645,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id96">
 <h3>New Features<a class="headerlink" href="#id96" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16262,12 +16262,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17266,12 +17266,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17279,10 +17275,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17295,12 +17295,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17375,7 +17375,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17385,7 +17385,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -17408,7 +17408,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>

--- a/docs-archive/apache-airflow/2.9.3/release_notes.html
+++ b/docs-archive/apache-airflow/2.9.3/release_notes.html
@@ -44,9 +44,9 @@
     </script>
     <!-- End Matomo Code -->
 
-    
+
 </head><body class="td-section">
-    
+
 
 <header>
     <nav class="js-navbar-scroll navbar">
@@ -85,38 +85,38 @@
             <div class="navbar__menu-content" id="main_navbar">
 
                 <div class="navbar__links-container">
-                    
+
                         <a class="navbar__text-link" href="/community/">
                             Community
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/meetups/">
                             Meetups
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/docs/">
                             Documentation
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/use-cases/">
                             Use Cases
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/announcements/">
                             Announcements
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/blog/">
                             Blog
                         </a>
-                    
+
                         <a class="navbar__text-link" href="/ecosystem/">
                             Ecosystem
                         </a>
-                    
+
                 </div>
 
-                
+
 
             </div>
 
@@ -160,38 +160,38 @@
                 <div class="navbar__menu-content" id="main_navbar">
 
                     <div class="navbar__links-container">
-                        
+
                             <a class="navbar__text-link" href="/community/">
                                 Community
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/meetups/">
                                 Meetups
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/docs/">
                                 Documentation
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/use-cases/">
                                 Use Cases
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/announcements/">
                                 Announcements
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/blog/">
                                 Blog
                             </a>
-                        
+
                             <a class="navbar__text-link" href="/ecosystem/">
                                 Ecosystem
                             </a>
-                        
+
 
                     </div>
-                    
+
 
                 </div>
             </div>
@@ -202,8 +202,8 @@
 
 
     <div class="roadmap container-fluid td-default base-layout">
-        
-        
+
+
     <div class="content-drawer-wrapper">
         <button class="content-drawer__toggle-button" id="content-open-button">
 
@@ -1442,10 +1442,10 @@
             </div>
         </div>
     </div>
-        
+
         <div class="d-flex">
-            
-            
+
+
     <div class="td-sidebar desktop-only d-print-none">
 
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
@@ -2601,15 +2601,15 @@
 
 </style>
     </div>
-            
 
-            
+
+
 
             <main class="col-12 col-md-9 col-xl-8" role="main">
-                
 
 
-    
+
+
 
 
 
@@ -2617,20 +2617,20 @@
 <div role="navigation" aria-label="breadcrumbs navigation" class="d-none d-md-block d-print-none">
 
     <ul class="breadcrumb">
-        
+
             <li class="breadcrumb-item"><a href="index.html" class="icon icon-home"> Home</a></li>
-            
+
             <li class="breadcrumb-item"><a href="release_notes.html"> Release Notes</a></li>
-        
+
     </ul>
 </div>
-                
+
                 <div class="rst-content">
                     <div class="document">
                             <div class="documentwrapper">
                                 <div class="bodywrapper">
                                     <div class="body" role="main">
-                                        
+
   <blockquote>
 <div></div></blockquote>
 <div class="section" id="release-notes">
@@ -5740,7 +5740,7 @@ applied by setting the DAG to use a custom timetable.</p>
 <div class="section" id="id100">
 <h3>New Features<a class="headerlink" href="#id100" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22">AIP-48</a>)</p></li>
+<li><p>Add Data-aware Scheduling (<a class="reference external" href="https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling">AIP-48</a>)</p></li>
 <li><p>Add <code class="docutils literal notranslate"><span class="pre">&#64;task.short_circuit</span></code> TaskFlow decorator (#25752)</p></li>
 <li><p>Make <code class="docutils literal notranslate"><span class="pre">execution_date_or_run_id</span></code> optional in <code class="docutils literal notranslate"><span class="pre">tasks</span> <span class="pre">test</span></code> command (#26114)</p></li>
 <li><p>Automatically register DAGs that are used in a context manager (#23592, #26398)</p></li>
@@ -16357,12 +16357,12 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </div>
-                
-            </main>
-            
 
-            
-            
+            </main>
+
+
+
+
     <nav class="wy-nav-side-toc">
         <div class="wy-menu-vertical">
             <ul>
@@ -17372,12 +17372,8 @@ It was not confirmed, but a workaround was found by changing the default back to
 
         </div>
     </nav>
-            
+
         </div>
-        
-
-
-    
 
 
 
@@ -17385,10 +17381,14 @@ It was not confirmed, but a workaround was found by changing the default back to
 
 
 
-    
-        
-            
-        
+
+
+
+
+
+
+
+
         <div class="base-layout--button">
             <a href="https://github.com/apache/airflow/edit/main/docs/apache-airflow/release_notes.rst" rel="nofollow">
 
@@ -17401,12 +17401,12 @@ It was not confirmed, but a workaround was found by changing the default back to
                 </button>
             </a>
         </div>
-    
+
 
     </div>
 
 
-    
+
 
 <footer>
     <div class="footer-section footer-section__media-section">
@@ -17481,7 +17481,7 @@ It was not confirmed, but a workaround was found by changing the default back to
             </a>
 
         </div>
-        
+
 
         <div class="footer-section__media-section--button-with-text">
             <span class="footer-section__media-section--text">Want to be a part of Apache Airflow?</span>
@@ -17491,7 +17491,7 @@ It was not confirmed, but a workaround was found by changing the default back to
 
             </a>
         </div>
-        
+
 
     </div>
     <div class="footer-section footer-section__policies-section">
@@ -17514,7 +17514,7 @@ It was not confirmed, but a workaround was found by changing the default back to
                 <a href="https://www.apache.org/security/" class="footer-section__policies-section--policy-item">
                     <span>Security</span>
                 </a>
-                
+
 
             </div>
         </div>


### PR DESCRIPTION
**DO NOT MERGE!**

This PR changes all references to label AIP-48 in the PR tracker. It's one line change

https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+label%3AAIP-48+milestone%3A%22Airflow+2.4.0%22

to:

https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Amerged+milestone%3A%22Airflow+2.4.0%22+label%3Aarea%3Adata-aware-scheduling

but we need to do it for all versions starting 2.4.0

Closes: https://github.com/apache/airflow/issues/47839

**Migration procedure:**
1. Wait for green build
2. Change all issues / PRs with `AIP-48` label to `area:data-aware-scheduling` label
3. Merge PR
4. Verify links working in doc site (after doc build finish)
5. Remove AIP-48 and area:dataset labels
