### PR TITLE
Modified airflow-site security policy

### DIFF
--- a/landing-pages/site/static/.htaccess
+++ b/landing-pages/site/static/.htaccess
@@ -42,4 +42,4 @@ RedirectMatch Permanent ^/docs/apache-airflow/(stable|2\.[0-9.]+)/profiling.html
 
 # Allow loading YouTube content after ensuring consent.
 # Additional allowances to be coordinated with privacy team
-Header set Content-Security-Policy "frame-src https://www.youtube-nocookie.com https://www.youtube.com"
+Header set Content-Security-Policy "frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com https://airflow.apache.org;"


### PR DESCRIPTION
Fixes https://github.com/apache/airflow/issues/46656. 

So apparently the celery graphviz is not loading due to a content security policy (CSP) of the website. 

The `frame-src` directive in CSP specifies valid sources for nested browsing contexts, such as those created by `<frame>` and `<iframe>` elements. In this case, the policy only allows content to be framed from `https://www.youtube-nocookie.com` and `https://www.youtube.com`. Since the URL https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/_images/graphviz-1eeec310b5d1b747eecc7861ba8b33cc7bdcd23c.svg is not included in the allowed sources, the browser blocks it from being framed. 

To fix this, we're adding `https://airflow.apache.org;` to the CSP and this should hopefully fix the problem. 