### PR TITLE
Blog: Add support for multiple authors in list and detail views

### DIFF
--- a/landing-pages/site/layouts/blog/content.html
+++ b/landing-pages/site/layouts/blog/content.html
@@ -30,20 +30,35 @@
     </div>
     <p class="blogpost-content__metadata--title">{{ .Title }}</p>
     <div class="blogpost-content__metadata--author">
-        <span class="blogpost-content__metadata--author">
-            {{ .Params.author }}
-        </span>
-        {{ with .Params.github }}
-            <a href="https://github.com/{{ . }}/" class="blogpost-content__metadata--social-media-icon">
+        {{ if .Params.authors }}
+          {{ range .Params.authors }}
+            <span class="blogpost-content__metadata--author-name">{{ .name }}</span>
+            {{ with .github }}
+              <a href="https://github.com/{{ . }}/" class="blogpost-content__metadata--social-media-icon">
                 {{ with resources.Get "icons/github-small.svg" }}{{ .Content | safeHTML }}{{ end }}
-            </a>
-        {{ end }}
-        {{ with .Params.linkedin }}
-            <a href="https://linkedin.com/in/{{ . }}/" class="blogpost-content__metadata--social-media-icon">
+              </a>
+            {{ end }}
+            {{ with .linkedin }}
+              <a href="https://linkedin.com/in/{{ . }}/" class="blogpost-content__metadata--social-media-icon">
                 {{ with resources.Get "icons/linkedin-small.svg" }}{{ .Content | safeHTML }}{{ end }}
+              </a>
+            {{ end }}
+            <br>
+          {{ end }}
+        {{ else if .Params.author }}
+          <span class="blogpost-content__metadata--author-name">{{ .Params.author }}</span>
+          {{ with .Params.github }}
+            <a href="https://github.com/{{ . }}/" class="blogpost-content__metadata--social-media-icon">
+              {{ with resources.Get "icons/github-small.svg" }}{{ .Content | safeHTML }}{{ end }}
             </a>
+          {{ end }}
+          {{ with .Params.linkedin }}
+            <a href="https://linkedin.com/in/{{ . }}/" class="blogpost-content__metadata--social-media-icon">
+              {{ with resources.Get "icons/linkedin-small.svg" }}{{ .Content | safeHTML }}{{ end }}
+            </a>
+          {{ end }}
         {{ end }}
-    </div>
+      </div>
     <p class="blogpost-content__metadata--description">{{ .Params.description }}</p>
 </div>
 <div class="markdown-content">

--- a/landing-pages/site/layouts/partials/boxes/blogpost.html
+++ b/landing-pages/site/layouts/partials/boxes/blogpost.html
@@ -34,7 +34,23 @@
                 {{ .Params.title }}
             </a>
         </p>
-        <p class="box-event__blogpost--author">{{ .Params.author }}</p>
+        {{ if .Params.authors }}
+        <p class="box-event__blogpost--author">
+          {{ $total := len .Params.authors }}
+          {{ range $index, $a := .Params.authors }}
+            {{ if $a.linkedin }}
+              <a href="https://linkedin.com/in/{{ $a.linkedin }}" target="_blank" rel="noopener">{{ $a.name }}</a>
+            {{ else if $a.github }}
+              <a href="https://github.com/{{ $a.github }}" target="_blank" rel="noopener">{{ $a.name }}</a>
+            {{ else }}
+              {{ $a.name }}
+            {{ end }}
+            {{ if lt (add $index 1) $total }}, {{ end }}
+          {{ end }}
+        </p>
+        {{ else if .Params.author }}
+            <p class="box-event__blogpost--author">{{ .Params.author }}</p>
+        {{ end }}
         <p class="box-event__blogpost--description">{{ .Params.description }}</p>
         <div class="mt-auto">
             <a href="{{ .RelPermalink }}">


### PR DESCRIPTION
This will help cases like https://airflow.apache.org/blog/airflow-three-point-oh-is-here/

Added the following:
- Supports `authors` list with name, GitHub, and LinkedIn
- Updates `boxes/blogpost.html` for list cards
- Updates `layouts/blog/content.html` for post detail view