### PR TITLE
Add workflow_dispatch to docs build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches: ['main']
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This will help to refresh airflow-site when new versions published to S3. No empty commit is required to trigger.