### PR TITLE
Quote descriptions with special characters in chart index file

### DIFF
--- a/landing-pages/site/static/index.yaml
+++ b/landing-pages/site/static/index.yaml
@@ -30,7 +30,7 @@ entries:
           links:
           - name: '#50897'
             url: https://github.com/apache/airflow/pull/50897
-        - description: Unify k8s labels & add some missing k8s labels
+        - description: 'Unify k8s labels & add some missing k8s labels'
           kind: changed
           links:
           - name: '#49522'
@@ -40,12 +40,12 @@ entries:
           links:
           - name: '#49727'
             url: https://github.com/apache/airflow/pull/49727
-        - description: Replace break function in ``pod-launcher-rolebinding`` template
+        - description: 'Replace break function in ``pod-launcher-rolebinding`` template'
           kind: fixed
           links:
           - name: '#49219'
             url: https://github.com/apache/airflow/pull/49219
-        - description: Add ``webserver_config.py`` file to api-server
+        - description: 'Add ``webserver_config.py`` file to api-server'
           kind: fixed
           links:
           - name: '#50108'


### PR DESCRIPTION
Artifacthub is complaining about these - unfortunately, I'm not sure if its complaining from the index file or the entry in Chart.yaml. One way to find out...