### PR TITLE
Better index page for "Documentation".

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -21,6 +21,24 @@ executing tasks in isolated subprocesses and interacting with Airflow resources
 (e.g., Connections, Variables, XComs, Metrics, Logs, and OpenLineage events) at runtime. The goal of task-sdk is to decouple DAG authoring from Airflow internals (Scheduler, API Server, etc.), providing a forward-compatible, stable interface for writing and maintaining DAGs across Airflow versions.
 [Read the documentation >>](/docs/task-sdk/stable/index.html)
 
+## [Docker stack](/docs/docker-stack/index.html)
+
+Airflow has an official Dockerfile and Docker image published in DockerHub as a convenience package for
+installation. You can extend and customize the image according to your requirements and use it in
+your own deployments.
+[Read the documentation >>](/docs/docker-stack/index.html)
+
+
+## [Helm Chart](/docs/helm-chart/stable/index.html)
+
+Airflow has an official Helm Chart that will help you set up your own Airflow on a cloud/on-prem Kubernetes environment and leverage its scalable nature to support a large group of users. Thanks to Kubernetes, we are not tied to a specific cloud provider.
+[Read the documentation >>](/docs/helm-chart/stable/index.html)
+
+## [Python API Client](https://github.com/apache/airflow-client-python)
+
+Airflow releases official Python API client that can be used to easily interact with Airflow REST API from Python code.
+[See the client repository](https://github.com/apache/airflow-client-python)
+
 ## [Providers packages](/docs/apache-airflow-providers/index.html)
 
 Providers packages include integrations with third party projects. They are versioned and released independently of the Apache Airflow core.
@@ -269,26 +287,3 @@ More about the removal process can be found in the
 </ul>
 
 {{< /rawhtml >}}
-
-## [Docker stack](/docs/docker-stack/index.html)
-
-Airflow has an official Dockerfile and Docker image published in DockerHub as a convenience package for
-installation. You can extend and customize the image according to your requirements and use it in
-your own deployments.
-[Read the documentation >>](/docs/docker-stack/index.html)
-
-
-## [Helm Chart](/docs/helm-chart/stable/index.html)
-
-Airflow has an official Helm Chart that will help you set up your own Airflow on a cloud/on-prem Kubernetes environment and leverage its scalable nature to support a large group of users. Thanks to Kubernetes, we are not tied to a specific cloud provider.
-[Read the documentation >>](/docs/helm-chart/stable/index.html)
-
-## [Python API Client](https://github.com/apache/airflow-client-python)
-
-Airflow releases official Python API client that can be used to easily interact with Airflow REST API from Python code.
-[See the client repository](https://github.com/apache/airflow-client-python)
-
-## [Go API Client](https://github.com/apache/airflow-client-go)
-
-Airflow releases official Go API client that can be used to easily interact with Airflow REST API from Go code.
-[See the client repository](https://github.com/apache/airflow-client-go)


### PR DESCRIPTION
* Moving Docker Stack, Helm Chart and Python Client above providers (on most of the screens you will still see providers and realise you should scroll down to see all of them.

* Removing Go Client - we do no release it any more.