### PR TITLE
Removing DoubleCloud from 'Airflow as a Service'

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -49,8 +49,6 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Airflow with Restack](https://www.restack.io/store/airflow) - Managed Apache Airflow on Restack Cloud or bring your own cloud: AWS EKS, GCP GKE, or Azure AKS. Allowing you to use the latest version of Airflow with your own DAGs. Connect your repo to the Restack GitHub app for built-in CI/CD.
 
-[DoubleCloud Managed Service for Apache Airflow](https://double.cloud/services/managed-airflow/) - Managed Apache Airflow on DoubleCloud platform.
-
 &nbsp;
 
 ## Other deployments methods


### PR DESCRIPTION
Double cloud has wound down operations. Would be better to remove this from the official airflow ecosystem page to avoid misleading URLs. As of October 2023, new customers are no longer allowed to signup. 



