### PR TITLE
Add airflow-mcp-hipposys and Airflow Schedule Insights on ecosystem

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -223,6 +223,9 @@ Apache Airflow releases the [Official Apache Airflow Community Chart](https://ai
 
 [mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow) - [MCP](https://modelcontextprotocol.com) server for Apache Airflow
 
+[Airflow Schedule Insights](https://github.com/hipposys-ltd/airflow-schedule-insights) - Airflow Plugin from [Hipposys](https://newsletter.hipposys.ai/) that can predict the next DAG run for both scheduled DAGs and event-driven DAGs, visualizing everything in a beautiful Gantt chart.
+
+
 &nbsp;
 
 ## Airflow Provider System Test Dashboards

--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -225,6 +225,7 @@ Apache Airflow releases the [Official Apache Airflow Community Chart](https://ai
 
 [Airflow Schedule Insights](https://github.com/hipposys-ltd/airflow-schedule-insights) - Airflow Plugin from [Hipposys](https://newsletter.hipposys.ai/) that can predict the next DAG run for both scheduled DAGs and event-driven DAGs, visualizing everything in a beautiful Gantt chart.
 
+[airflow-mcp-hipposys](https://github.com/hipposys-ltd/airflow-mcp) - [MCP](https://modelcontextprotocol.com) server for Apache Airflow with safe and unsafe modes, and can predict next DAG runs if the instance has the Airflow Schedule Insights plugin installed.
 
 &nbsp;
 


### PR DESCRIPTION
Hey @potiuk , 

Following up on your suggestion in Slack to add our tools to the Airflow ecosystem page - here's the PR! These are the MCP Server and Airflow plugin from [this post](https://www.linkedin.com/posts/egorseno_airflow-astronomer-devtools-activity-7353745367181488128-Uvp0?utm_source=share&utm_medium=member_desktop&rcm=ACoAAC1CwQsBx7nr1t6yomC0WgSTBfXKQAYQvv8) that was published yesterday.
The MCP Server offers both safe and unsafe operational modes and integrates seamlessly with our Schedule Insights plugin to provide DAG run predictions.
Would you be able to review and merge this addition to the Airflow ecosystem? Thanks so much!