### PR TITLE
fix: typo in docs build command

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -437,7 +437,7 @@ To release a new documentation, follow these steps:
 2.  To build documentation, run following commands:
     ```bash
     cd "${AIRFLOW_REPO}" && git checkout "${AIRFLOW_VERSION}"
-    cd "${AIRFLOW_REPO}" && breeze build-docs'
+    cd "${AIRFLOW_REPO}" && breeze build-docs
     ```
 
 3.  Copy generated files from `${AIRFLOW_REPO}/docs/_build/html` to `${AIRFLOW_SITE_REPO}/docs-archive/<version>/`


### PR DESCRIPTION
The previous command had an extraneous single quote (`cd "${AIRFLOW_REPO}" && breeze build-docs'`)
Updated to: `cd "${AIRFLOW_REPO}" && breeze build-docs`