### PR TITLE
Serve /schemas/ from the S3 bucket/Cloudfront too.

### DIFF
--- a/landing-pages/site/static/.htaccess
+++ b/landing-pages/site/static/.htaccess
@@ -1,6 +1,7 @@
 RewriteEngine On
 
-RewriteCond %{REQUEST_URI} ^/docs [NC]
+RewriteCond %{REQUEST_URI} ^/docs [OR]
+RewriteCond %{REQUEST_URI} ^/schemas/
 RewriteCond %{REQUEST_URI} !^/docs/index\.html$ [NC]
 RewriteCond %{REQUEST_URI} !^/docs/index\.xml$ [NC]
 RewriteRule (.*) https://d7fnmbhf26p21.cloudfront.net/$1 [P]


### PR DESCRIPTION
This gives us a place outside of versioned docs to Publish Open API or JSON
schemas.

I removed the `NC` flag which makes it do a case-insensitve comparission as
the case actually matters here, if we have a request to `/Docs` it will 404,
so there's no point sending it to S3

This is #1228 but for the staging branch too
