### PR TITLE
Remove Airflow with Restack

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -47,8 +47,6 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Yandex Managed Service for Apache Airflow](https://cloud.yandex.com/en/services/managed-airflow) - Managed Apache Airflow on Yandex Cloud
 
-[Airflow with Restack](https://www.restack.io/store/airflow) - Managed Apache Airflow on Restack Cloud or bring your own cloud: AWS EKS, GCP GKE, or Azure AKS. Allowing you to use the latest version of Airflow with your own DAGs. Connect your repo to the Restack GitHub app for built-in CI/CD.
-
 &nbsp;
 
 ## Other deployments methods


### PR DESCRIPTION
Restack offering was added in https://github.com/apache/airflow-site/pull/869
I don't see they are offering Airflow as service any longer the link leads to their main company page.
cc @martinibach if I was mistaken please raise new PR to change that