### PR TITLE
Remove Kafka from Async Providers

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -103,8 +103,6 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Astronomer Providers](https://github.com/astronomer/astronomer-providers) - A collection of Async Operators and Sensors for Apache Airflow built and maintained by Astronomer.
 
-[Airflow Kafka Provider](https://github.com/astronomer/airflow-provider-kafka) - Apache Airflow Kafka provider containing Deferrable Operators & Sensors.
-
 &nbsp;
 
 ## Third Party Airflow Helm Charts


### PR DESCRIPTION
Kafka provider is fully integrated as Airflow official provider.

cc @tatiana 