### PR TITLE
Update PostgreSQL URL in integrations.json

### DIFF
--- a/landing-pages/site/static/integrations.json
+++ b/landing-pages/site/static/integrations.json
@@ -733,7 +733,7 @@
   {
     "name": "PostgreSQL",
     "logo": "/integration-logos/postgres/Postgres.png",
-    "url": "/docs/apache-airflow-providers-postgres/stable/operators/postgres_operator_howto_guide.html"
+    "url": "/docs/apache-airflow-providers-postgres/stable/operators.html"
   },
   {
     "name": "Presto",


### PR DESCRIPTION
The current link for Postgres under the Integrations section leads to a 404