### PR TITLE
Update website banner to show airflow survey 2025

### DIFF
--- a/landing-pages/site/layouts/partials/navbar.html
+++ b/landing-pages/site/layouts/partials/navbar.html
@@ -18,8 +18,8 @@
 */}}
 
 {{ $cover := .HasShortcode "blocks/cover" }}
-<a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
-    Airflow Summit 2025 is coming October 07-09. Register now to secure your spot!
+<a href="https://astronomer.typeform.com/airflowsurvey25" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
+    Complete the airflow survey & get a free airflow 3 certification!
 </a>
 <nav class="js-navbar-scroll navbar" style="top: 40px;">
     <div class="navbar__icon-container">

--- a/sphinx_airflow_theme/sphinx_airflow_theme/header.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/header.html
@@ -18,8 +18,8 @@
 #}
 
 <header>
-    <a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
-        Airflow Summit 2025 is coming October 07-09. Register now to secure your spot!
+    <a href="https://astronomer.typeform.com/airflowsurvey25" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
+        Complete the airflow survey & get a free airflow 3 certification!
     </a>
     <nav class="js-navbar-scroll navbar" style="top: 40px;">
         <div class="navbar__icon-container">


### PR DESCRIPTION
Airflow Summit's over, so I am updating the banner to display the airflow survey 2025.

<img width="2546" height="1010" alt="image" src="https://github.com/user-attachments/assets/be1335c6-35a8-4525-a61d-c4aa8de23fda" />

Redirects to:
<img width="2546" height="1055" alt="image" src="https://github.com/user-attachments/assets/7583b83c-ce54-4f25-9a02-23fc7794efd9" />
