### PR TITLE
[CI] Lychee: automated check of links in doc

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -17,7 +17,7 @@
 
 name: Check Doc Links
 
-# This workflow checks all links from Airflow doc via Lychee
+# This workflow checks all links from Airflow doc via Lychee: https://github.com/lycheeverse/lychee
 # The check is done directly from website in case build process creates / transforms links
 # It has a schedule to run at least once a day in order to detect dangling external links in case there
 # is no activity on this repo itself.


### PR DESCRIPTION
Hi,
adding a github workflow to validate - at least daily - that all links from Airflow Doc are correct.

This workflow checks all links from Airflow doc via Lychee: https://github.com/lycheeverse/lychee

Specific aspects:

1. The check is done directly from website in case build process creates / transforms links
2. It has a schedule to run at least once a day in order to detect dangling external links in case there
is no activity on this repo itself.

When tested on 'https://airflow.apache.org/docs/' from my repo clone,  it delivers this report:

<img width="335" height="511" alt="image" src="https://github.com/user-attachments/assets/7f100550-d4fb-4873-8538-14fbb91a0997" />

Didier


