### PR TITLE
Fix Main animation not displaying

### DIFF
--- a/landing-pages/src/js/headerAnimation.js
+++ b/landing-pages/src/js/headerAnimation.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import * as p5 from "p5";
+import p5 from "p5";
 import debounce from "lodash/debounce";
 import {documentReady} from "./utils.js";
 


### PR DESCRIPTION
Fixed an issue where the header animation was not rendered due to an incorrect p5 import.

## Before
<img width="1832" height="1527" alt="image" src="https://github.com/user-attachments/assets/4c604983-6032-4129-abcc-174590c8bef3" />


## Now
https://github.com/user-attachments/assets/cbc652a5-74cf-4408-ba38-d5a5cfada733

