### PR TITLE
Update ownership: airflow-mcp and Airflow Schedule Insights now owned by Ponder

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -219,7 +219,7 @@ Apache Airflow releases the [Official Apache Airflow Community Chart](https://ai
 
 [mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow) - [MCP](https://modelcontextprotocol.com) server for Apache Airflow
 
-[Airflow Schedule Insights](https://github.com/ponderedw/airflow-schedule-insights) - Airflow Plugin from [Ponder](https://newsletter.ponder.ai/) that can predict the next DAG run for both scheduled DAGs and event-driven DAGs, visualizing everything in a beautiful Gantt chart.
+[Airflow Schedule Insights](https://github.com/ponderedw/airflow-schedule-insights) - Airflow Plugin from [Ponder](https://newsletter.ponder.co) that can predict the next DAG run for both scheduled DAGs and event-driven DAGs, visualizing everything in a beautiful Gantt chart.
 
 [airflow-mcp-ponder](https://github.com/ponderedw/airflow-mcp) - [MCP](https://modelcontextprotocol.com) server for Apache Airflow with safe and unsafe modes, and can predict next DAG runs if the instance has the Airflow Schedule Insights plugin installed.
 


### PR DESCRIPTION
Hey @potiuk ,

Following up on this pull request (https://github.com/apache/airflow-site/pull/1225), the ownership of airflow-mcp and Airflow Schedule Insights has moved to Ponder (and not Hipposys), so I’d like to update a couple of links on the ecosystem page. Thanks! 🙂