### PR TITLE
Update newsletter link in community page

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -38,7 +38,7 @@ menu:
                 </p>
             </ol>
             {{< /accordion >}}
-            {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://cdn.forms-content-1.sg-form.com/0e736095-efa6-11ef-a7a0-f25cb9c40f09) on recent events and communications in the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
+            {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://cdn.forms-content-1.sg-form.com/44820aed-844a-11f0-9142-367766e5a240) on recent events and communications in the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
             <p class="bodytext__medium--brownish-grey">You will learn about:</p>
             <ul class="ticks-blue mx-auto">
                 <li>recent releases</li>


### PR DESCRIPTION
The newsletter link on the community page was outdated.
I updated it according to the Slack thread below.

https://apache-airflow.slack.com/archives/C03T0AVNA6A/p1756411648371809?thread_ts=1754504665.717909&cid=C03T0AVNA6A

## before
https://github.com/user-attachments/assets/4a74dfde-84ca-405a-9f80-84935bfe7b48


## after
https://github.com/user-attachments/assets/339925a2-c92a-40dc-9b91-38fc40a8b841