### PR TITLE
refactor: unify section headers in home page layout

### DIFF
--- a/landing-pages/site/assets/scss/_home-page.scss
+++ b/landing-pages/site/assets/scss/_home-page.scss
@@ -28,15 +28,12 @@
     }
   }
 }
-.principles-header {
-  margin-top: 20px;
-  margin-bottom: 4px;
-}
+.home-section-header {
+  margin-top: 80px;
+  margin-bottom: 60px;
 
-.integrations-header {
-  margin-bottom: 60px; // to be changed when searchbox is added
-
-  @media (max-width: $mobile)  {
+  @media (max-width: $mobile) {
+    margin-top: 40px;
     margin-bottom: 30px;
   }
 }

--- a/landing-pages/site/layouts/index.html
+++ b/landing-pages/site/layouts/index.html
@@ -36,7 +36,7 @@
 
 {{ define "main" }}
     <div>
-        <h4 class="page-header principles-header">Principles</h4>
+        <h4 class="page-header home-section-header">Principles</h4>
         <div class="text-with-icon-list">
             {{ partial "text-with-icon" (dict "logo_path" "icons/scalable-icon.svg" "header" "Scalable" "text" "Apache Airflow&#174; has a modular architecture and uses a message queue to orchestrate an arbitrary number of workers. Airflow™ is ready to scale to infinity.") }}
             {{ partial "text-with-icon" (dict "logo_path" "icons/dynamic-icon.svg" "header" "Dynamic" "text" "Apache Airflow&#174; pipelines are defined in Python, allowing for dynamic pipeline generation. This allows for writing code that instantiates pipelines dynamically.") }}
@@ -45,7 +45,7 @@
         </div>
     </div>
     <div>
-        <h4 class="page-header">Features</h4>
+        <h4 class="page-header home-section-header">Features</h4>
         <div class="features-list">
             {{ partial "feature" (dict "logo_path" "icons/pure-python-icon.svg" "header" "Pure Python" "text" "No more command-line or XML black-magic! Use standard Python features to create your workflows, including date time formats for scheduling and loops to dynamically generate tasks. This allows you to maintain full flexibility when building your workflows.") }}
             {{ partial "feature" (dict "logo_path" "icons/useful-ui-icon.svg" "header" "Useful UI" "text" "Monitor, schedule and manage your workflows via a robust and modern web application. No need to learn old, cron-like interfaces. You always have full insight into the status and logs of completed and ongoing tasks.") }}
@@ -56,7 +56,7 @@
 
     </div>
     <div>
-        <h4 class="page-header integrations-header">Integrations</h4>
+        <h4 class="page-header home-section-header">Integrations</h4>
         <div id="integrations">
             <script type="application/x-template" id="integration-template">
                 <a class="list-item" href="">
@@ -92,7 +92,7 @@
         </div>
     </div>
     <div>
-    <h4 class="page-header">From the Blog</h4>
+    <h4 class="page-header home-section-header">From the Blog</h4>
 
     <div class="blog-snippet-list">
         {{ range first 3 (where .Site.RegularPages "Section" "blog") }}


### PR DESCRIPTION
This PR refactors the home page layout by unifying section header styles.

## Why
Currently, each section had slightly different spacing and styles, which caused visual inconsistency. This change improves maintainability and provides a consistent look across the home page.

<img width="2168" height="1397" alt="image" src="https://github.com/user-attachments/assets/7edd5c03-d316-4b48-926d-69b73981e732" />

## Change
Ensures all main sections (Principles, Features, Integrations, From the Blog) share the same header styling.

## Screenshot

https://github.com/user-attachments/assets/9dcc88fe-9a0c-49c7-baa5-1d09a26298d5

<img width="2168" height="1397" alt="image" src="https://github.com/user-attachments/assets/c5a5efc6-5723-4e43-a092-db9144d07679" />

