### PR TITLE
Fix typo: change 'inddex' to 'index' in integrationList.js

### DIFF
--- a/landing-pages/src/js/integrationList.js
+++ b/landing-pages/src/js/integrationList.js
@@ -78,7 +78,7 @@ function handleIntegration() {
       .then((integrations) => {
         integrations = shuffle(integrations);
         integrations.sort(sortByLogoAvailability);
-        integrations.forEach((i, index) => i.inddex = index);
+        integrations.forEach((i, index) => i.index = index);
         return Promise.resolve(integrations);
       });
     fetchIntegrationRequest = request;


### PR DESCRIPTION
# 🛠️ Fix #1291 — Correct Typo in Property Name (`inddex` → `index`)

While working on the previous issue, I noticed a small typo in `integrationList.js` (line 81) where the property `inddex` was used instead of the correct `index`.

This caused integration objects to receive the wrong property name, which could break any functionality depending on the `index` field.

---

## ✅ What I Fixed
- Corrected the typo: `inddex` → `index`
- Ensured integrations now receive the correct `index` property

---

## 📌 Impact
This fix ensures integrations behave as expected and prevents bugs related to incorrect property access.

---

<img width="707" height="252" src="https://github.com/user-attachments/assets/035d052f-2c56-4bbb-be47-aa3d2ba0478d" />
