### PR TITLE
Fix Blog navbar active state on tag and taxonomy pages

### DIFF
--- a/landing-pages/site/assets/scss/_navbar.scss
+++ b/landing-pages/site/assets/scss/_navbar.scss
@@ -27,7 +27,7 @@
   justify-content: flex-start;
   border-bottom: solid 1px map-get($colors, very-light-pink);
   z-index: 32;
-  padding: 10px 60px;
+  padding: 30px 60px;
 
   &__menu-container {
     flex-grow: 1;

--- a/landing-pages/site/data/integrations.json
+++ b/landing-pages/site/data/integrations.json
@@ -1,0 +1,1 @@
+../static/integrations.json


### PR DESCRIPTION
### What does this PR do?
#1310 

Keeps the **Blog** navbar item highlighted for all blog-related pages,
including taxonomy pages such as `/blog/tags/*`.

@potiuk 