### PR TITLE
Remove newsletter from the link

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -38,17 +38,6 @@ menu:
                 </p>
             </ol>
             {{< /accordion >}}
-            {{< accordion title="Subscribe to the newsletter" description="[Get regular monthly updates](https://cdn.forms-content-1.sg-form.com/44820aed-844a-11f0-9142-367766e5a240) on recent events and communications in the Airflow community." logo_path="icons/join-devlist-icon.svg" >}}
-            <p class="bodytext__medium--brownish-grey">You will learn about:</p>
-            <ul class="ticks-blue mx-auto">
-                <li>recent releases</li>
-                <li>upcoming and recent events</li>
-                <li>the PR of the Month</li>
-                <li>recent blog posts and guides</li>
-                <li>activity on the Dev list.</li>
-            </ul>
-            {{< /accordion >}}
-
             {{< accordion title="Improve documentation" description="Additions and improvements to the documentation are always welcome!" logo_path="icons/documentation-icon.svg" >}}
             <ol class="counter-blue mx-auto">
                 <li>Open a PR with your changes.</li>


### PR DESCRIPTION
The newsleter is prepared and send from outside of the PMC control, so we should not have link on our page suggesting otherwise, it might be added to the ecosystem page separately.