### PR TITLE
Fix Community page accordions opening by default

### DIFF
--- a/landing-pages/site/content/en/community/_index.html
+++ b/landing-pages/site/content/en/community/_index.html
@@ -9,7 +9,7 @@ menu:
     <div class="community--dev">
         <div class="community--accordion-container">
             <h6 class="community--header-persona">Want to contribute?</h6>
-            {{< accordion title="Join the Dev list" description="The Dev list is the preferred channel for announcements, proposals and votes." logo_path="icons/join-devlist-icon.svg" open="true">}}
+            {{< accordion title="Join the Dev list" description="The Dev list is the preferred channel for announcements, proposals and votes." logo_path="icons/join-devlist-icon.svg">}}
                 <p class="bodytext__medium--brownish-grey">
                     Manage your <b>subscription</b>:
                 </p>
@@ -27,7 +27,7 @@ menu:
                     For answers to ad hoc questions, try asking in the official <b>Airflow Slack</b> first. See <b>"Ask a question"</b> below for details and additional resources.
                 </p>
             {{< /accordion >}}
-            {{< accordion title="Join the community on Slack" description="Connect with other contributors" logo_path="icons/ask-question-icon.svg" open="true">}}
+            {{< accordion title="Join the community on Slack" description="Connect with other contributors" logo_path="icons/ask-question-icon.svg">}}
             <ol class="counter-blue mx-auto">
                 <p class="bodytext__medium--brownish-grey">
                     After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join
@@ -70,7 +70,7 @@ menu:
     <div class="community--user">
         <div class="community--accordion-container">
             <h6 class="community--header-persona">Are you a user?</h6>
-            {{< accordion title="Join the community on Slack" description="Connect with other users, get help, exchange best practices with other users." logo_path="icons/ask-question-icon.svg" open="true">}}
+            {{< accordion title="Join the community on Slack" description="Connect with other users, get help, exchange best practices with other users." logo_path="icons/ask-question-icon.svg">}}
             <ol class="counter-blue mx-auto">
                 <p class="bodytext__medium--brownish-grey">
                     After <a href="https://apache-airflow-slack.herokuapp.com/">creating an account</a>, join


### PR DESCRIPTION
### What does this PR do?

This PR improves the Community page user experience by preventing multiple
accordion sections from being expanded by default on page load.

Previously, several accordions were initialized with `open="true"

Before Changes: 
<img width="1882" height="766" alt="Screenshot 2025-12-14 170620" src="https://github.com/user-attachments/assets/ece45c00-fdd4-4159-98bc-b2bd5146ea3c" />
<img width="1894" height="766" alt="Screenshot 2025-12-14 170635" src="https://github.com/user-attachments/assets/40fa27cd-bb7b-423c-9ee9-0e25877a42ee" />

After Chnages:
<img width="1882" height="904" alt="Screenshot 2025-12-14 170654" src="https://github.com/user-attachments/assets/7304395d-01a0-4c20-90e0-1a79f3651d54" />


### Why is this change needed?

- Reduces visual clutter on initial page load
- Restores expected accordion behavior
- Provides more consistent UI/UX

LGTM :) Kindly verify and merge it.

From now, i am more careful about PRs 😊 @choo121600 @potiuk 

