### PR TITLE
Hidden content and heading improved

### DIFF
--- a/landing-pages/site/assets/scss/_rst-content.scss
+++ b/landing-pages/site/assets/scss/_rst-content.scss
@@ -21,7 +21,7 @@
   color: #707070;
 
   h1 {
-    margin-top: 0;
+    scroll-margin-top: 130px;
     margin-bottom: 30px;
     font-weight: 500;
     font-family: "Rubik", sans-serif;


### PR DESCRIPTION
### What does this PR do?

When navigating to section anchors (for example by clicking a heading link or using
a URL fragment), the target heading and its content are partially hidden behind the
fixed navigation bar.

Before Changes:

https://github.com/user-attachments/assets/659ef6c5-a145-4e58-aa23-45de28552204

After Changes: 

https://github.com/user-attachments/assets/32346b79-bcd1-42f3-838c-f6f4b0a4b00f



This PR fixes the issue by adding an appropriate scroll margin so that anchored
headings are positioned correctly below the navbar.

### Why is this change needed?

- Anchor navigation currently hides headings under the fixed header
- This affects readability and user navigation, especially on Announcements pages
- The issue is noticeable when sharing or opening deep links

Thanks!


