### PR TITLE
Fix syntax highlighting in blog code blocks

### DIFF
--- a/landing-pages/site/assets/scss/_highlights.scss
+++ b/landing-pages/site/assets/scss/_highlights.scss
@@ -20,7 +20,9 @@
 @import "pygments/light";
 @import "pygments/dark";
 
-.chroma, .highlight {
+// Light theme syntax highlighting for RST/Sphinx docs only
+// (Chroma for blog markdown uses Docsy theme colors)
+.highlight {
   background-color: #ffffff;
 
   .lntd {
@@ -86,8 +88,8 @@
 }
 
 pre {
-  margin: 40px 0;
-  padding: 16px 20px;
+  margin: 1rem 0;
+  padding: 1rem;
   border: solid 1px map-get($colors, very-light-pink);
   border-radius: 5px;
   width: 100%;
@@ -98,7 +100,8 @@ pre {
 }
 
 [data-bs-theme="dark"] {
-  .chroma, .highlight {
+  // Dark theme for RST/Sphinx docs only
+  .highlight {
     background-color: #0d1117;
 
     .hl {

--- a/landing-pages/site/assets/scss/_markdown-content.scss
+++ b/landing-pages/site/assets/scss/_markdown-content.scss
@@ -24,14 +24,23 @@
     margin-bottom: 20px;
   }
 
-  p, span {
+  p {
     @extend .bodytext__medium--brownish-grey;
     margin-bottom: 30px;
     margin-top: 20px;
   }
 
-  pre span {
-    @extend .monotext--brownish-grey;
+  // Only apply to spans outside of code blocks
+  > p, > span {
+    @extend .bodytext__medium--brownish-grey;
+    margin-bottom: 30px;
+    margin-top: 20px;
+  }
+
+  // Reset margin for spans inside code blocks
+  .chroma span {
+    margin-bottom: 0;
+    margin-top: 0;
   }
 
   img {

--- a/landing-pages/site/assets/scss/main-custom.scss
+++ b/landing-pages/site/assets/scss/main-custom.scss
@@ -51,6 +51,7 @@
 @import "scroll-to-top";
 @import "content-drawer";
 @import "dropdown";
+@import "td/code-dark"; // Import Docsy Chroma themes for blog markdown code blocks
 @import "highlights";
 @import "share-social-media";
 @import "four-oh-four";

--- a/landing-pages/site/assets/scss/pygments/_dark.scss
+++ b/landing-pages/site/assets/scss/pygments/_dark.scss
@@ -36,6 +36,8 @@
  */
 
 [data-bs-theme="dark"] {
+// Scope Pygments to .rst-content only (don't override Chroma for blog markdown)
+.rst-content {
 pre { line-height: 125%; }
 td.linenos .normal { color: #6e7681; background-color: #0d1117; padding-left: 5px; padding-right: 5px; }
 span.linenos { color: #6e7681; background-color: #0d1117; padding-left: 5px; padding-right: 5px; }
@@ -122,4 +124,5 @@ span.linenos.special { color: #e6edf3; background-color: #6e7681; padding-left: 
 .highlight .vi { color: #79C0FF } /* Name.Variable.Instance */
 .highlight .vm { color: #79C0FF } /* Name.Variable.Magic */
 .highlight .il { color: #A5D6FF } /* Literal.Number.Integer.Long */
+}
 }

--- a/landing-pages/site/assets/scss/pygments/_light.scss
+++ b/landing-pages/site/assets/scss/pygments/_light.scss
@@ -36,6 +36,8 @@
  */
 
 [data-bs-theme="light"] {
+  // Scope Pygments to .rst-content only (don't override Chroma for blog markdown)
+  .rst-content {
   pre { line-height: 125%; }
   td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
   span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
@@ -80,4 +82,5 @@
   .highlight .sr { color: #A31515 } /* Literal.String.Regex */
   .highlight .s1 { color: #A31515 } /* Literal.String.Single */
   .highlight .ss { color: #A31515 } /* Literal.String.Symbol */
+  }
 }


### PR DESCRIPTION
## Problem

Blog code blocks and Sphinx documentation had incorrect syntax highlighting where different Python token types (e.g., `from` keyword and `airflow.sdk` namespace) appeared with identical colors. Additionally, code blocks had excessive vertical spacing.

## Changes

### Syntax Highlighting
- **Scope Pygments styles to `.rst-content`**: Prevents Pygments (used by Sphinx docs) from overriding Chroma (used by Hugo blog posts)
- **Import Docsy Chroma dark theme**: Added `@import "td/code-dark";` to enable proper token colorization in blog posts
- **Remove `.chroma` from `_highlights.scss`**: Changed selectors from `.chroma, .highlight` to just `.highlight` to target only Sphinx/RST content

### Spacing Fixes
- **Exclude code spans from margin**: Split `p, span` selector and added `.chroma span` reset to prevent 30px bottom margin on code tokens
- **Remove pre span override**: Removed rule that was overriding Chroma's monospace fonts
- **Reduce code block padding**: Changed `pre` margin/padding from 40px/16px to 1rem for more compact display

## Impact

- ✅ **Blog posts**: Now use Chroma with distinct colors for different token types
- ✅ **Sphinx docs**: Unaffected - Pygments styles remain scoped to `.rst-content`. Theme will be rebuilt with these changes during release.
- ✅ **Spacing**: Code blocks no longer have excessive line height

## Testing

Tested on http://localhost:3009/blog/airflow-3.1.0/ - verified distinct colors for `from` (purple) vs `airflow.sdk` (red/pink) and proper spacing.