### PR TITLE
Use Docsy `_partials` overrides for footer and head hook

### DIFF
--- a/landing-pages/site/layouts/_partials/footer.html
+++ b/landing-pages/site/layouts/_partials/footer.html
@@ -55,7 +55,6 @@
 .icon-facebook:hover svg path,
 .icon-facebook:hover svg circle { fill: #1877F2 !important; }
 </style>
-</style>
 
 <footer>
     <div class="footer-section footer-section__media-section">

--- a/landing-pages/site/layouts/_partials/hooks/head-end.html
+++ b/landing-pages/site/layouts/_partials/hooks/head-end.html
@@ -42,5 +42,4 @@
 <link rel="preload" href="{{ relURL .header.js }}" as="script">
 {{ $vendorsHeader := index . "vendors~header" }}
 <link rel="preload" href="{{ relURL $vendorsHeader.js }}" as="script">
-
 {{ end }}


### PR DESCRIPTION
This PR adds back missing footers including Foundation, License & trademark notes + Matomo JS integration

## Before

<img width="1714" height="636" alt="image" src="https://github.com/user-attachments/assets/caa97cde-e75a-4a9d-ac1b-9fb2c887a57f" />

##After
<img width="1705" height="851" alt="image" src="https://github.com/user-attachments/assets/ab726aa5-ff71-41ab-8e8f-570ed1208507" />


Fix footer rendering by moving our overrides to Hugo v0.146+’s `_partials` path so they actually override Docsy’s footer and hooks.

## Why
This repo builds with **Hugo v0.146.0** (see CI). In Hugo v0.146.0’s new template system, **`layouts/partials/` is renamed to `layouts/_partials/`** ([Hugo: New template system in v0.146.0](https://gohugo.io/templates/new-templatesystem-overview/)). Any `layouts/<dir>` **not** starting with `_` is treated as the root of a **Page path**, not a special template bucket ([same doc](https://gohugo.io/templates/new-templatesystem-overview/)).

As a result, `landing-pages/site/layouts/partials/footer.html` was not being used to override the theme footer. Docsy’s default footer (minimal) was rendered instead.

## Rule of thumb (Hugo >= 0.146.0)
- Use `layouts/_partials/...` for reusable partials.
- Use `layouts/_shortcodes/...` for shortcodes.
- Treat `layouts/<dir-without-leading-_>/...` as Page-path scoped templates (e.g. `layouts/docs/...`) ([Hugo: New template system in v0.146.0](https://gohugo.io/templates/new-templatesystem-overview/)).
- When overriding a theme template, mirror the theme’s **relative path** under `layouts/` (project wins only when the relative path matches):
  - [Hugo: Template lookup order](https://gohugo.io/templates/lookup-order/)

## Related Docsy references
- Docsy docs: injecting code via hook partials `hooks/head-end.html` / `hooks/body-end.html` ([Docsy: Look and Feel → Customizing templates](https://www.docsy.dev/docs/content/lookandfeel/))
- Docsy theme sources (for context on what we’re overriding):
  - Footer partial: https://github.com/google/docsy/blob/v0.12.0/layouts/_partials/footer.html
  - Head hook placeholder: https://github.com/google/docsy/blob/v0.12.0/layouts/_partials/hooks/head-end.html

