### PR TITLE
Improved the unecessary background and border line

### DIFF
--- a/landing-pages/site/assets/scss/_community-page.scss
+++ b/landing-pages/site/assets/scss/_community-page.scss
@@ -92,7 +92,6 @@
      top: 263px;
      overflow-x: auto;
      overflow-y: auto;
-     border-left: 1px solid rgba(211, 211, 211, 0.128);
      height: 100px;
      padding-left: 30px;
      max-height: -webkit-calc(100vh - 163px);

--- a/landing-pages/site/assets/scss/_rst-content.scss
+++ b/landing-pages/site/assets/scss/_rst-content.scss
@@ -758,8 +758,6 @@ body {
 
   // Sidebar navigation
   .wy-nav-side-toc {
-    background-color: var(--bs-secondary-bg) !important;
-    border-color: var(--bs-border-color);
 
     a {
       color: var(--bs-emphasis-color) !important; // Changed from secondary-color for better readability, !important to override .roadmap specificity


### PR DESCRIPTION
This PR fixes the unecessary border and background in the wy-nav-side-toc class in both the theme:

**Before changes:**

<img width="1610" height="634" alt="Screenshot 2025-12-18 220647" src="https://github.com/user-attachments/assets/f82f7f05-9d7c-4a77-b1d9-bbfffeceaedd" />
<img width="1885" height="500" alt="Screenshot 2025-12-18 225139" src="https://github.com/user-attachments/assets/ef49ce77-bfcf-4a0c-840e-10902ceb38ac" />

**After changes: Matching the UI layout in both theme.**

<img width="1845" height="419" alt="Screenshot 2025-12-19 004858" src="https://github.com/user-attachments/assets/37b2436c-d53a-4398-8827-06d243a4d969" />
<img width="1798" height="427" alt="Screenshot 2025-12-19 004815" src="https://github.com/user-attachments/assets/7be77ec3-0a53-4534-ad0d-752131540312" />


Thanks:)