### PR TITLE
Fix white background in sidebar for dark mode

### DIFF
--- a/landing-pages/site/assets/scss/_content-drawer.scss
+++ b/landing-pages/site/assets/scss/_content-drawer.scss
@@ -41,7 +41,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: white;
+  background-color: var(--bs-body-bg, #fff);
   transform: translateX(-100%);
   transition: 0.2s ease-out;
   z-index: 100;


### PR DESCRIPTION
**Before**:
<img width="483" height="768" alt="image" src="https://github.com/user-attachments/assets/c81820b3-115d-48b9-b8ae-7d4afd0a586f" />

**After**:

<img width="378" height="706" alt="image" src="https://github.com/user-attachments/assets/fc6d724d-38a0-41e1-b743-2ba4efb15da2" />
