### PR TITLE
Update version label to have better visibility in dark mode

### DIFF
--- a/landing-pages/site/assets/scss/_rst-content.scss
+++ b/landing-pages/site/assets/scss/_rst-content.scss
@@ -856,6 +856,16 @@ body {
     }
   }
 
+  // Style the version label to be theme-aware
+  .version-label {
+    @extend .bodytext__medium--greyish-brown;
+    color: var(--bs-secondary-color);
+  }
+
+  [data-bs-theme="dark"] .version-label {
+    color: var(--bs-body-color);
+  }
+
   // Breadcrumbs
   .breadcrumb {
     background-color: transparent;

--- a/sphinx_airflow_theme/sphinx_airflow_theme/version-selector.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/version-selector.html
@@ -20,7 +20,7 @@
 <div id="docs-version-selector" class="docs-version-selector sidebar__version-selector">
     <a class="dropdown-toggle" href="#" id="versionDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true"
        aria-expanded="false">
-        <span class="bodytext__medium--greyish-brown">Version: </span><span class="version">{{ version }}</span>
+        <span class="version-label">Version: </span><span class="version">{{ version }}</span>
     </a>
     <div class="dropdown-menu" aria-labelledby="versionDropdown">
 


### PR DESCRIPTION
**Before**:
<img width="368" height="395" alt="image" src="https://github.com/user-attachments/assets/222e3959-4a45-4aed-88b5-6c8e9846f993" />


**After**
<img width="471" height="583" alt="image" src="https://github.com/user-attachments/assets/83bf93d5-18b2-4799-94f7-644cbbfa7736" />
