### PR TITLE
Add Stuttgart as Meetup

### DIFF
--- a/landing-pages/site/static/meetups.json
+++ b/landing-pages/site/static/meetups.json
@@ -3,70 +3,63 @@
     "city": "Bangalore",
     "country": "India",
     "date": "",
-    "members": 1860,
+    "members": 2350,
     "url": "https://www.meetup.com/Bangalore-Apache-Airflow-Meetup/"
   },
   {
     "city": "Charlotte",
     "country": "USA",
     "date": "",
-    "members": 86,
+    "members": 131,
     "url": "https://www.meetup.com/charlotte-apache-airflow-meetup/"
   },
   {
     "city": "Chicago",
     "country": "USA",
     "date": "",
-    "members": 239,
+    "members": 272,
     "url": "https://www.meetup.com/chicago-apache-airflow-meetup-group/"
   },
   {
     "city": "Hyderabad",
     "country": "India",
     "date": "",
-    "members": 664,
+    "members": 944,
     "url": "https://www.meetup.com/hyderabad-apache-airflow-meetup-group/"
-  },
-  {
-    "city": "Seoul",
-    "country": "Korea",
-    "date": "",
-    "members": 278,
-    "url": "https://www.meetup.com/apache-airflow-users-korea/"
   },
   {
     "city": "Lisbon",
     "country": "Portugal",
     "date": "",
-    "members": 122,
+    "members": 126,
     "url": "https://www.meetup.com/lisbon-apache-airflow-meetup-group/"
   },
   {
     "city": "London",
     "country": "United Kingdom",
     "date": "",
-    "members": 1221,
+    "members": 1242,
     "url": "https://www.meetup.com/London-Apache-Airflow-Meetup/"
   },
   {
     "city": "Melbourne",
     "country": "Australia",
     "date": "",
-    "members": 222,
+    "members": 284,
     "url": "https://www.meetup.com/Melbourne-Apache-Airflow-Meetup/"
   },
   {
     "city": "New York",
     "country": "USA",
     "date": "",
-    "members": 2322,
+    "members": 2449,
     "url": "https://www.meetup.com/NYC-Apache-Airflow-Meetup/"
   },
   {
     "city": "Paris",
     "country": "France",
     "date": "",
-    "members": 1357,
+    "members": 1401,
     "url": "https://www.meetup.com/Paris-Apache-Airflow-Meetup/"
   },
   {
@@ -80,77 +73,84 @@
     "city": "Prague",
     "country": "Czech Republic",
     "date": "",
-    "members": 122,
+    "members": 150,
     "url": "https://www.meetup.com/prague-airflow-meetup-group/"
   },
   {
     "city": "Pune",
     "country": "India",
     "date": "",
-    "members": 338,
+    "members": 438,
     "url": "https://www.meetup.com/pune-apache-airflow-meetup-group/"
-  },
-  {
-    "city": "Tel Aviv-Yafo",
-    "country": "Israel",
-    "date": "",
-    "members": 1031,
-    "url": "https://www.meetup.com/tel-aviv-apache-airflow-meetup/"
   },
   {
     "city": "San Francisco Bay Area",
     "country": "USA",
     "date": "",
-    "members": 2357,
+    "members": 2452,
     "url": "https://www.meetup.com/Bay-Area-Apache-Airflow-Incubating-Meetup/"
-  },
-  {
-    "city": "Washington D.C.",
-    "country": "USA",
-    "date": "",
-    "members": 152,
-    "url": "https://www.meetup.com/dc-area-apache-airflow-meetup/"
   },
   {
     "city": "S\u00e3o Paulo",
     "country": "Brazil",
     "date": "",
-    "members": 464,
+    "members": 512,
     "url": "https://www.meetup.com/sao-paulo-apache-airflow-meetup-group/"
+  },
+  {
+    "city": "Seoul",
+    "country": "Korea",
+    "date": "",
+    "members": 358,
+    "url": "https://www.meetup.com/apache-airflow-users-korea/"
+  },
+  {
+    "city": "Stuttgart",
+    "country": "Germany",
+    "date": "",
+    "members": 10,
+    "url": "https://www.meetup.com/meetup-group-nmgokliw/"
+  },
+  {
+    "city": "Tel Aviv-Yafo",
+    "country": "Israel",
+    "date": "",
+    "members": 1065,
+    "url": "https://www.meetup.com/tel-aviv-apache-airflow-meetup/"
   },
   {
     "city": "Tokyo",
     "country": "Japan",
     "date": "",
-    "members": 213,
+    "members": 215,
     "url": "https://www.meetup.com/Tokyo-Apache-Airflow-incubating-Meetup/"
   },
   {
     "city": "Toronto",
     "country": "Canada",
     "date": "",
-    "members": 342,
+    "members": 454,
     "url": "https://www.meetup.com/toronto-apache-airflow-meetup/"
-  },
-  {
-    "city": "Taipei",
-    "country": "Taiwan",
-    "date": "",
-    "members": 36,
-    "url": "https://www.meetup.com/taipei-py/"
   },
   {
     "city": "Vancouver",
     "country": "Canada",
     "date": "",
-    "members": 197,
+    "members": 202,
     "url": "https://www.meetup.com/vancouver-apache-airflow-meetup/"
+  },
+  {
+    "city": "Washington D.C.",
+    "country": "USA",
+    "date": "",
+    "members": 178,
+    "url": "https://www.meetup.com/dc-area-apache-airflow-meetup/"
   },
   {
     "city": "Warsaw",
     "country": "Poland",
     "date": "",
-    "members": 237,
+    "members": 322,
     "url": "https://www.meetup.com/pl-PL/warsaw-apache-airflow-meetup-group/"
   }
 ]


### PR DESCRIPTION
As we want to start hosting Apache Airflow Meetups in Stuttgart-Germany as well this is updating the site page.

Changes:
- Adding Stuttgart as new Meetup group
- Noticed that Taipeh user group referenced in https://www.meetup.com/taipei-py/ seems to be vanished... @Lee-W @uranusjr is this correct? Removing it here
- Re-ordered by alphabet, was quite inconsistent meanwhile
- Updated counts of members as of today

FYI @Briana-Okyere 