### PR TITLE
Fix navbar toggle button in dev mode

### DIFF
--- a/landing-pages/src/js/drawer.js
+++ b/landing-pages/src/js/drawer.js
@@ -29,10 +29,7 @@ const toggleDrawer = () => {
   closeIcon.classList.toggle("visible");
 };
 
-if (toggleButton) {
-  if (toggleButton.handler) {
-    toggleButton.removeEventListener("click", toggleButton.handler);
-  }
-  toggleButton.handler = toggleDrawer;
-  toggleButton.addEventListener("click", toggleButton.handler);
+if (toggleButton && !toggleButton.dataset.drawerInitialized) {
+  toggleButton.addEventListener("click", toggleDrawer);
+  toggleButton.dataset.drawerInitialized = "true";
 }


### PR DESCRIPTION
## Copilot Summary

This pull request improves the initialization logic for the navigation drawer toggle button in the `drawer.js` file. The main change ensures that the event listener for toggling the navigation drawer is only attached once, preventing potential duplicate event handlers.

**Event listener initialization improvements:**

* Added a check to ensure the `#navbar-toggle-button` exists and hasn't already been initialized before attaching the click event listener, using a `data-drawer-initialized` attribute to track initialization. [[1]](diffhunk://#diff-ace34ecc23fabaa0646f458d1dff849d6ce479b0d43295845102505ea7813731R20-R21) [[2]](diffhunk://#diff-ace34ecc23fabaa0646f458d1dff849d6ce479b0d43295845102505ea7813731L30-R35)