### PR TITLE
Fix content security policy

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
@@ -257,6 +257,22 @@
         <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
     {%- endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      script-src 'self' 'unsafe-inline' 'unsafe-eval'
+        https://www.apachecon.com
+        https://www.communityovercode.org
+        https://*.apache.org
+        https://*.scarf.sh;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      font-src 'self' https://fonts.gstatic.com data:;
+      img-src 'self' data: https://*.apache.org https://*.scarf.sh;
+      connect-src 'self' https://*.apache.org https://*.scarf.sh;
+      frame-ancestors 'none';
+      object-src 'none';
+      base-uri 'self';
+      form-action 'self';
+    ">
     {{- metatags }}
     {%- block htmltitle %}
         <title>{{ title|striptags|e }}{{ titlesuffix }}</title>


### PR DESCRIPTION
## Copilot Summary

This pull request introduces a significant security improvement to the `sphinx_airflow_theme` by adding a Content Security Policy (CSP) header to the `layout.html` template. The CSP restricts the sources for scripts, styles, fonts, images, and other resources, enhancing the protection against cross-site scripting (XSS) and related attacks.

**Security enhancements:**

* Added a `<meta http-equiv="Content-Security-Policy">` tag to `layout.html` to enforce strict resource loading policies, specifying allowed sources for scripts, styles, fonts, images, connections, and more. This helps prevent XSS and content injection vulnerabilities.