### PR TITLE
Fixed the fill in diff theme of scroll svg

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/suggest_change_button.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/suggest_change_button.html
@@ -39,7 +39,7 @@
             {% set github_link = 'https://' ~ github_host|default("github.com") ~ '/' ~  github_user ~ '/' ~ github_repo ~ '/' ~ theme_vcs_pageview_mode|default("blob") ~ '/' ~  github_version ~ conf_py_path ~ pagename ~ suffix %}
         {% endif %}
         <div class="base-layout--button fade-target">
-            <button class="btn-hollow btn-brown with-box-shadow"
+            <button class="btn-hollow btn-brown with-box-shadow btn-with-icon"
             onclick="window.scrollTo({ top: 0, behavior: 'smooth' });"
             aria-label="Scroll to top"
             >


### PR DESCRIPTION
Added the button class in the scroll icon in sphinx page so it can behave as the icon on the normal page:

**Before : Same fill on both theme**

<img width="1913" height="281" alt="Screenshot 2025-12-28 153406" src="https://github.com/user-attachments/assets/777c3d77-f644-48f1-9edd-2be668a41b36" />
<img width="1898" height="228" alt="Screenshot 2025-12-28 153414" src="https://github.com/user-attachments/assets/cd8197eb-ea11-4abe-a28b-452ab2e84ecf" />


**After : Matching the theme layout**

<img width="1896" height="229" alt="Screenshot 2025-12-28 153354" src="https://github.com/user-attachments/assets/e46a7ad3-40a9-4975-8b5d-44509623da36" />
<img width="1901" height="295" alt="Screenshot 2025-12-28 153342" src="https://github.com/user-attachments/assets/c3c934bb-60b0-4f95-a707-11db635673e7" />

Thanks :)