### PR TITLE
Fix active mode in dark mode menu

### DIFF
--- a/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
+++ b/sphinx_airflow_theme/sphinx_airflow_theme/layout.html
@@ -359,7 +359,7 @@
         return storedTheme
       }
 
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      return 'auto'
     }
 
     const setTheme = theme => {
@@ -387,10 +387,18 @@
       document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
         element.classList.remove('active')
         element.setAttribute('aria-pressed', 'false')
+        const checkIcon = element.querySelector('.bi.ms-auto')
+        if (checkIcon) {
+            checkIcon.classList.add('d-none')
+        }
       })
 
       btnToActive.classList.add('active')
       btnToActive.setAttribute('aria-pressed', 'true')
+      const activeCheckIcon = btnToActive.querySelector('.bi.ms-auto')
+      if (activeCheckIcon) {
+          activeCheckIcon.classList.remove('d-none')
+      }
       activeThemeIcon.setAttribute('href', svgOfActiveBtn)
       const themeSwitcherLabel = `${themeSwitcherText ? themeSwitcherText.textContent : ''} (${btnToActive.dataset.bsThemeValue})`
       themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)


### PR DESCRIPTION
## Copilot Summary

This pull request updates the theme-switching logic and UI in the `layout.html` file of the `sphinx_airflow_theme`. The main improvements are to the theme selection behavior and the visual feedback for the active theme.

Theme selection logic:

* The default theme selection now returns `'auto'` instead of checking the user's `prefers-color-scheme` setting, simplifying the logic for determining the initial theme.

Visual feedback for theme selection:

* When switching themes, the checkmark icon (`.bi.ms-auto`) is now hidden for all theme options and shown only for the active theme, improving clarity about which theme is currently selected.