### PR TITLE
Bump apache/infrastructure-actions/allowlist-check to latest main

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@e9aff90d22568865baa7d1d12676c01fa29f59c4  # main
+      - uses: apache/infrastructure-actions/allowlist-check@70ab74bb5ccc96bb2b9bc51404f1f09cfb909aec  # main


### PR DESCRIPTION
## Summary
- Bump `apache/infrastructure-actions/allowlist-check` pin from `e9aff90` to `70ab74b` (latest commit on `main`) in `.github/workflows/asf-allowlist-check.yml`.

## Test plan
- [ ] CI passes (ASF Allowlist Check workflow runs successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)