### PR TITLE
Fix typo in Airflow 3.2.0 blog post

### DIFF
--- a/landing-pages/site/content/en/blog/airflow-3.2.0/index.md
+++ b/landing-pages/site/content/en/blog/airflow-3.2.0/index.md
@@ -234,7 +234,7 @@ async def load_xml_files(files):
                 # Do something with result or accumulate it and return it as an XCom
 ```
 
-# Updated securiy model
+# Updated security model
 
 We are working on improving isolation and improving security of Airflow deployments and in order to make our users better informed of what expectations they should have for Airflow security, we updated the security model to reflect changes implemented in Airflow 3.2.0 and explain future improvements that we work on in this area. See more:  [Airflow Security Model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html).
 


### PR DESCRIPTION
Fixes a typo in the Airflow 3.2.0 release blog post: "securiy" → "security" in the section heading "Updated securiy model".