### PR TITLE
Fix broken blog Atom feed

### DIFF
--- a/landing-pages/site/config.toml
+++ b/landing-pages/site/config.toml
@@ -68,6 +68,7 @@ description = "Platform created by the community to programmatically author, sch
 # Everything below this are Site Params
 
 [params]
+canonicalBaseURL = "https://airflow.apache.org"
 charset = "utf-8"
 copyright = "The Apache Software Foundation"
 privacy_policy = "https://policies.google.com/privacy"

--- a/landing-pages/site/layouts/blog/list.xml
+++ b/landing-pages/site/layouts/blog/list.xml
@@ -20,9 +20,9 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>" | safeHTML }}
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ .Site.Title }} Blog</title>
-  <link href="{{ $base }}{{ .Permalink }}" rel="alternate"/>
-  <link href="{{ $base }}{{ .Permalink }}index.xml" rel="self" type="application/atom+xml"/>
-  <id>{{ $base }}{{ .Permalink }}</id>
+  <link href="{{ $base }}{{ .RelPermalink }}" rel="alternate"/>
+  <link href="{{ $base }}{{ .RelPermalink }}index.xml" rel="self" type="application/atom+xml"/>
+  <id>{{ $base }}{{ .RelPermalink }}</id>
 {{ $pages := sort .Pages "Lastmod" "desc" }}
 {{ with index $pages 0 }}
   <updated>{{ .Lastmod.Format "2006-01-02T15:04:05Z" }}</updated>
@@ -30,14 +30,15 @@
 {{ range sort .Pages "Lastmod" "desc" }}
   <entry>
     <title>{{ .Title }}</title>
-    <link href="{{ $base }}{{ .Permalink }}" rel="alternate"/>
-    <id>{{ $base }}{{ .Permalink }}</id>
+    <link href="{{ $base }}{{ .RelPermalink }}" rel="alternate"/>
+    <id>{{ $base }}{{ .RelPermalink }}</id>
     <published>{{ .PublishDate.Format "2006-01-02T15:04:05Z" }}</published>
     <updated>{{ .Lastmod.Format "2006-01-02T15:04:05Z" }}</updated>
     <author>
       <name>Apache Airflow</name>
     </author>
-    <content type="html">{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content>
+    {{- $content := replace .Content "]]>" "]]]]><![CDATA[>" -}}
+    <content type="html">{{ printf "<![CDATA[%s]]>" $content | safeHTML }}</content>
   </entry>
   {{ end }}
 </feed>

--- a/landing-pages/site/layouts/blog/list.xml
+++ b/landing-pages/site/layouts/blog/list.xml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
@@ -15,14 +15,14 @@
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-*/}}
-
-<?xml version="1.0" encoding="utf-8"?>
+*/ -}}
+{{- $base := .Site.Params.canonicalBaseURL | default "" -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>" | safeHTML }}
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ .Site.Title }} Blog</title>
-  <link href="{{ .Permalink }}" rel="alternate"/>
-<link href="{{ .Permalink }}index.xml" rel="self" type="application/atom+xml"/>
-<id>{{ .Permalink }}</id>
+  <link href="{{ $base }}{{ .Permalink }}" rel="alternate"/>
+  <link href="{{ $base }}{{ .Permalink }}index.xml" rel="self" type="application/atom+xml"/>
+  <id>{{ $base }}{{ .Permalink }}</id>
 {{ $pages := sort .Pages "Lastmod" "desc" }}
 {{ with index $pages 0 }}
   <updated>{{ .Lastmod.Format "2006-01-02T15:04:05Z" }}</updated>
@@ -30,14 +30,14 @@
 {{ range sort .Pages "Lastmod" "desc" }}
   <entry>
     <title>{{ .Title }}</title>
-    <link href="{{ .Permalink }}" rel="alternate"/>
-    <id>{{ .Permalink }}</id>
+    <link href="{{ $base }}{{ .Permalink }}" rel="alternate"/>
+    <id>{{ $base }}{{ .Permalink }}</id>
     <published>{{ .PublishDate.Format "2006-01-02T15:04:05Z" }}</published>
     <updated>{{ .Lastmod.Format "2006-01-02T15:04:05Z" }}</updated>
     <author>
       <name>Apache Airflow</name>
     </author>
-    <content type="html"><![CDATA[{{ .Content }}]]></content>
+    <content type="html">{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content>
   </entry>
   {{ end }}
 </feed>


### PR DESCRIPTION
## Summary

The blog Atom feed at `/blog/index.xml` has been producing invalid XML since it was introduced in #1391, reported in #1490. Three separate issues:

**1. Leading whitespace before XML declaration**
Hugo strips `{{/* */}}` template comments but preserves surrounding newlines. This produced two blank lines before `<?xml?>`, which the XML spec requires to be at byte 0. Fixed with Hugo's whitespace-trimming markers (`{{- -}}`).

**2. HTML escaping of XML constructs**
Hugo's `html/template` engine escaped `<?xml` → `&lt;?xml` and `<![CDATA[` → `&lt;![CDATA[`. Most browsers/readers partially recovered from this, but the feed was technically invalid. Fixed by piping through `safeHTML`.

**3. Relative URLs instead of absolute**
Since `baseURL = "/"`, `.Permalink` produced relative paths like `/blog/common-ai-provider/`. The Atom spec requires absolute URIs in `<link>` and `<id>` elements (this was the original request in #223). Added a `canonicalBaseURL` site param rather than changing the global `baseURL`, which could have unintended side effects across the site.

## Verification

```bash
cd landing-pages/site
hugo --quiet
python3 -c "
import xml.etree.ElementTree as ET
tree = ET.parse('public/blog/index.xml')
ns = {'atom': 'http://www.w3.org/2005/Atom'}
entries = tree.findall('.//atom:entry', ns)
print(f'Valid XML with {len(entries)} entries')
link = entries[0].find('atom:link', ns).get('href')
print(f'Entry link: {link}')
"
```

Output:
```
Valid XML with 37 entries
Entry link: https://airflow.apache.org/blog/common-ai-provider/
```

Closes #1490