### PR TITLE
Fix text selection blocked by sticky button containers

### DIFF
--- a/landing-pages/site/assets/scss/_base-layout.scss
+++ b/landing-pages/site/assets/scss/_base-layout.scss
@@ -29,6 +29,9 @@
     margin-right: 40px;
     bottom: 40px;
     z-index: 1;
+    pointer-events: none;
+
+    button, a { pointer-events: auto; }
   }
 
   &--suggestButton {
@@ -40,6 +43,9 @@
     margin-right: 40px;
     bottom: 40px;
     z-index: 1;
+    pointer-events: none;
+
+    button, a, .suggest-change-link { pointer-events: auto; }
   }
 
   &--button {
@@ -51,6 +57,9 @@
     bottom: 40px;
     justify-content: space-between;
     z-index: 1;
+    pointer-events: none;
+
+    button, a, .suggest-change-link { pointer-events: auto; }
   }
 
 }


### PR DESCRIPTION
## Summary

The scroll-to-top and suggest-change button containers are full-width sticky elements (`width: 100%`) that sit at the bottom of the page. Even though the visible buttons are small and positioned at the edges (left and right), the invisible container spans the entire page width, intercepting pointer events and preventing text selection behind it.

Fix: `pointer-events: none` on the three container variants (`--scrollButton`, `--suggestButton`, `--button`), with `pointer-events: auto` re-enabled on the actual clickable children.

One-line change per container — zero visual difference, text is now selectable everywhere.