### PR TITLE
Disable gradients in Docsy Bootstrap bundle for Sphinx theme

### DIFF
--- a/landing-pages/site/assets/scss/_variables_project.scss
+++ b/landing-pages/site/assets/scss/_variables_project.scss
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Project-level Bootstrap/Docsy variable overrides.
+// This file is loaded by Docsy's main.scss via @import "variables_project"
+// BEFORE Bootstrap and Docsy's own _variables.scss, so values set here
+// take precedence over !default declarations.
+
+$enable-gradients: false;


### PR DESCRIPTION
## Summary

The `$enable-gradients: false` from #1501 only affected our custom CSS bundle (`main-custom.min.css`). Docsy's `main.scss` compiles Bootstrap separately with its own `_variables.scss` that sets `$enable-gradients: true !default`.

Since the Sphinx docs theme reuses the Docsy-compiled `main.min.css` (via `site.sh prepare-theme`), the docs pages still had gradient overlays on buttons and navbar — especially visible in dark mode.

Fix: add `_variables_project.scss` — the [Docsy hook point](https://www.docsy.dev/docs/adding-content/lookandfeel/#project-style-files) loaded before Docsy's own variables — setting `$enable-gradients: false`.

## Verification

After rebuild, `main.min.css` contains only 1 reference to `--bs-gradient`: the `.bg-gradient` utility class (always emitted by Bootstrap). Zero component-level gradient usage (no `.btn`, `.navbar` etc).