### PR TITLE
docs(ecosystem): Add STACKIT Workflows

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -47,6 +47,8 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [Yandex Managed Service for Apache Airflow](https://cloud.yandex.com/en/services/managed-airflow) - Managed Apache Airflow on Yandex Cloud
 
+[STACKIT Workflows](https://docs.stackit.cloud/products/data-and-ai/workflows/) - Managed Apache Airflow on STACKIT Cloud
+
 &nbsp;
 
 ## Airflow Technology Consultancy Support


### PR DESCRIPTION
STACKIT Cloud is an European hyperscaler and offers Airflow as a managed service. 

This PR adds it to the Ecosystem page