### PR TITLE
Bump dependabot cooldown to 7 days, refresh allowlist-check pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     cooldown:
-      default-days: 4
+      default-days: 7
     directories:
       - /landing-pages
     schedule:
@@ -32,7 +32,7 @@ updates:
           - "*"
   - package-ecosystem: github-actions
     cooldown:
-      default-days: 4
+      default-days: 7
     directory: /
     schedule:
       interval: daily
@@ -42,7 +42,7 @@ updates:
           - "*"
   - package-ecosystem: pre-commit
     cooldown:
-      default-days: 4
+      default-days: 7
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@70ab74bb5ccc96bb2b9bc51404f1f09cfb909aec  # main
+      - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8  # main


### PR DESCRIPTION
## Summary
- Bump dependabot `cooldown.default-days` from 4 to 7 across all three ecosystems (npm, github-actions, pre-commit) to reduce churn.
- Refresh `apache/infrastructure-actions/allowlist-check` pinned SHA from `70ab74bb...` to `4e9c961f...` to match the version currently used in `apache/airflow`.
- All other action pins (`actions/checkout`, `actions/setup-python`, `actions/setup-node`, `actions/upload-artifact`, `aws-actions/configure-aws-credentials`) are already at the latest allowed versions — no changes needed.

## Test plan
- [ ] CI passes on this PR (build + ASF Allowlist Check workflows)