### PR TITLE
Add Akeyless and Vespa to docs index

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -57,6 +57,8 @@ Providers packages include integrations with third party projects. They are vers
 
   <li><a href="/docs/apache-airflow-providers-airbyte/stable/index.html"><code>Airbyte</code></a></li>
 
+  <li><a href="/docs/apache-airflow-providers-akeyless/stable/index.html"><code>Akeyless</code></a></li>
+
   <li><a href="/docs/apache-airflow-providers-alibaba/stable/index.html"><code>Alibaba</code></a></li>
 
   <li><a href="/docs/apache-airflow-providers-amazon/stable/index.html"><code>Amazon</code></a></li>
@@ -246,6 +248,8 @@ Providers packages include integrations with third party projects. They are vers
   <li><a href="/docs/apache-airflow-providers-trino/stable/index.html"><code>Trino</code></a></li>
 
   <li><a href="/docs/apache-airflow-providers-vertica/stable/index.html"><code>Vertica</code></a></li>
+
+  <li><a href="/docs/apache-airflow-providers-vespa/stable/index.html"><code>Vespa</code></a></li>
 
   <li><a href="/docs/apache-airflow-providers-weaviate/stable/index.html"><code>Weaviate</code></a></li>
 


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/66281

Add the new Akeyless and Vespa providers to the landing-page docs index.

This is the companion site change for the Airflow providers release docs update. Please merge it during the live release window so the new providers do not appear on the public index ahead of the release.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (GPT-5.4)

Generated-by: GitHub Copilot (GPT-5.4)