### PR TITLE
Fix wide documentation table overflow

### DIFF
--- a/landing-pages/site/assets/scss/_rst-content.scss
+++ b/landing-pages/site/assets/scss/_rst-content.scss
@@ -381,8 +381,11 @@ body {
     margin-bottom: 0 !important
   }
 
-  .wy-table-responsive table th {
-    white-space: nowrap
+  .wy-table-responsive table th,
+  .wy-table-responsive table td {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   code big, tt em, code em {


### PR DESCRIPTION
Closes #260.

This PR fixes wide documentation tables causing horizontal overflow by allowing table header and cell content to wrap within the available content width.

### What changed

- Updated Sphinx/RST documentation table styling in `_rst-content.scss`.
- Replaced forced `white-space: nowrap` on responsive table headers with normal wrapping.
- Added wrapping behavior for table cells and headers using `overflow-wrap: anywhere`.
- Kept the change focused on documentation table responsiveness.

### Testing

- Verified the diff only changes `landing-pages/site/assets/scss/_rst-content.scss`.
- Checked the resulting CSS block locally with:

```bash
sed -n '374,392p' landing-pages/site/assets/scss/_rst-content.scss