### PR TITLE
Implement autorefresh for meetup events

### DIFF
--- a/landing-pages/src/js/meetupsList.js
+++ b/landing-pages/src/js/meetupsList.js
@@ -18,11 +18,15 @@
  */
 
 
+const MEETUPS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 const runMeetups = () => {
   const root = document.querySelector(".meetups");
+
   if (!root) {
     return;
   }
+
   const templateText = root.querySelector("#meetup-template").innerText;
   const templateElement = document.createElement("div");
   templateElement.innerHTML = templateText;
@@ -33,88 +37,105 @@ const runMeetups = () => {
 
   let currentPage = 1;
   let currentQuery = "";
+  let allMeetups = [];
+
   const maxItemsOnPage = window.innerWidth < 1920 ? 8 : 10;
 
-  fetch("/meetups.json")
-    .then((response) => response.json())
-    .then((allMeetups) => {
+  const setMoreButtonVisibility = (visible) => {
+    moreButton.style.display = visible ? "" : "none";
+  };
 
-      const setMoreButtonVisibility = (visible) => {
-        moreButton.style.display = visible ? "" : "none";
-      };
+  const sortByIndex = (a, b) => {
+    return a.index - b.index;
+  };
 
-      setMoreButtonVisibility(true);
+  const createElement = (item) => {
+    const element = templateElement.cloneNode(true);
+    element.querySelector('[data-name="location"]').innerHTML = `${item.city}<br/>${item.country}`;
+    element.querySelector('[data-name="members-count"]').innerText = `${item.members} members`;
+    element.querySelector("a").href = item.url;
 
-      const sortByIndex = (a, b) => {
-        return a.index - b.index;
-      };
+    return element.firstElementChild;
+  };
 
-      const createElement = (item) => {
-        const element = templateElement.cloneNode(true);
-        element.querySelector('[data-name="location"]').innerHTML = `${item.city}<br/>${item.country}`;
-        element.querySelector('[data-name="members-count"]').innerText = `${item.members} members`;
-        element.querySelector("a").href = item.url;
+  const setItems = (items) => {
+    while (listItems.firstChild) {
+      listItems.removeChild(listItems.firstChild);
+    }
 
-        return element.firstElementChild;
-      };
+    if (items.length === 0) {
+      listItems.innerText = "No items";
+      return;
+    }
 
-      const setItems = (items) => {
-        if (items.length === 0) {
-          listItems.innerText = "No items";
-        } else {
-          while (listItems.firstChild) {
-            listItems.removeChild(listItems.firstChild);
-          }
-          items.forEach((item) => {
-            const element = createElement(item);
-            listItems.append(element);
-          });
-        }
-      };
-
-      const showItems = (keyword, page) => {
-        const showMoreButtonIfNeeded = (meetups) => {
-          setMoreButtonVisibility(meetups.length > (page * maxItemsOnPage));
-        };
-
-        const filterMatchingItems = (meetups) => {
-          if (!keyword) {
-            return meetups;
-          }
-          return meetups.filter((meetup) =>
-            meetup.city.toLowerCase().indexOf(keyword.toLowerCase()) >= 0 ||
-            meetup.country.toLowerCase().indexOf(keyword.toLowerCase()) >= 0 ||
-            (meetup.continent && meetup.continent.toLowerCase().indexOf(keyword.toLowerCase()) >= 0)
-          );
-        };
-
-        const filterVisible = (meetups) => {
-          meetups.sort(sortByIndex);
-          return meetups.slice(0, page * maxItemsOnPage);
-        };
-        const matchingItems = filterMatchingItems(allMeetups);
-        const visibleItems = filterVisible(matchingItems);
-        setItems(visibleItems);
-        showMoreButtonIfNeeded(matchingItems);
-      };
-
-      const setSearchQuery = (keyword) => {
-        currentQuery = keyword;
-        showItems(currentQuery, currentPage);
-      };
-
-      searchBox.addEventListener("keyup", () => {
-        currentPage = 1;
-        setSearchQuery(searchBox.value);
-      });
-
-      moreButton.addEventListener("click", () => {
-        currentPage = currentPage + 1;
-        setSearchQuery(searchBox.value);
-      });
-
-      setSearchQuery("");
+    items.forEach((item) => {
+      const element = createElement(item);
+      listItems.append(element);
     });
+  };
+
+  const filterMatchingItems = (meetups, keyword) => {
+    if (!keyword) {
+      return meetups;
+    }
+
+    return meetups.filter((meetup) =>
+      meetup.city.toLowerCase().includes(keyword.toLowerCase()) ||
+      meetup.country.toLowerCase().includes(keyword.toLowerCase()) ||
+      (meetup.continent && meetup.continent.toLowerCase().includes(keyword.toLowerCase()))
+    );
+  };
+
+  const filterVisible = (meetups, page) => {
+    return meetups.sort(sortByIndex).slice(0, page * maxItemsOnPage);
+  };
+
+  const showItems = () => {
+    const matchingItems = filterMatchingItems(allMeetups, currentQuery);
+    const visibleItems = filterVisible(matchingItems, currentPage);
+
+    setItems(visibleItems);
+    setMoreButtonVisibility(matchingItems.length > currentPage * maxItemsOnPage);
+  };
+
+  const loadMeetups = async() => {
+    const response = await fetch(`/meetups.json?updated=${Date.now()}`);
+
+    if (!response.ok) {
+      throw new Error("Unable to refresh meetup events");
+    }
+
+    const meetups = await response.json();
+
+    if (!Array.isArray(meetups)) {
+      throw new Error("Invalid meetup events response");
+    }
+
+    allMeetups = meetups;
+    showItems();
+  };
+
+  searchBox.addEventListener("keyup", () => {
+    currentPage = 1;
+    currentQuery = searchBox.value;
+    showItems();
+  });
+
+  moreButton.addEventListener("click", () => {
+    currentPage += 1;
+    showItems();
+  });
+
+  loadMeetups().catch(() => {
+    setItems([]);
+    setMoreButtonVisibility(false);
+  });
+
+  window.setInterval(() => {
+    loadMeetups().catch(() => {
+      // Keep currently rendered meetup events if a background refresh fails.
+    });
+  }, MEETUPS_REFRESH_INTERVAL_MS);
 };
 
 runMeetups();


### PR DESCRIPTION
## Summary

Implements automatic refresh for Meetup events on the Airflow site.

Previously, the Meetups page fetched `/meetups.json` only once when the page loaded. This PR updates the client-side meetup list logic so the page periodically refetches `/meetups.json` in the background and updates the rendered meetup cards without requiring a full page reload.

Closes #49

## What changed

- Added a refresh interval for Meetup event data.
- Refactored the Meetup list loading logic into a reusable `loadMeetups()` flow.
- Refetches `/meetups.json` periodically using a cache-busting query parameter.
- Preserves the existing Meetup page UI and layout.
- Preserves existing search behavior.
- Preserves existing “Show more” pagination behavior.
- Keeps already-rendered meetup events if a background refresh fails.
- Avoids adding any external API dependency or exposing secrets in the frontend.

## Why this approach

The current site already stores Meetup data in:

```txt
landing-pages/site/static/meetups.json
```

and the Meetups page loads this file client-side.

This PR keeps the existing data source and rendering flow, but adds automatic refresh behavior on top of it. This keeps the change small, safe, and focused while still solving the issue.

## Testing

Tested locally with:

```bash
cd landing-pages
yarn run lint:js
```

Also verified the Meetup page behavior locally:

- Meetup cards render correctly.
- Search by city/country still works.
- “Show more” still works.
- `/meetups.json` is refetched automatically in the background.
- Background refresh failure does not clear the currently rendered meetup list.

