### PR TITLE
Add Bilig WorkPaper to ecosystem tools

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -163,6 +163,8 @@ Apache Airflow releases the [Official Apache Airflow Community Chart](https://ai
 
 [Astro SDK](https://github.com/astronomer/astro-sdk) - Astro SDK allows rapid and clean development of Extract, Load, Transform workflows using Python and SQL, powered by Apache Airflow and maintained by Astronomer.
 
+[Bilig WorkPaper](https://proompteng.github.io/bilig/airflow-workpaper-dag.html) - Third-party Airflow DAG example for running formula-backed WorkPaper calculations with compact XCom proof and JSON readback verification.
+
 [Chartis](https://github.com/trejas/chartis) - Python package to convert Common Workflow Language (CWL) into Airflow DAG.
 
 [CWL-Airflow](https://github.com/Barski-lab/cwl-airflow) - Python package to extend Apache-Airflow 1.10.11 functionality with CWL v1.2 support.


### PR DESCRIPTION
## Summary

Adds Bilig WorkPaper to the Airflow ecosystem tools list as a third-party DAG example for formula-backed WorkPaper calculations.

The linked page shows an Airflow DAG path that returns compact XCom proof while keeping full WorkPaper JSON readback outside Airflow metadata.

## Validation

- `git diff --check`
- `UV_TOOL_DIR=/tmp/uv-tools uv tool run prek run --files landing-pages/site/content/en/ecosystem/_index.md`
