### PR TITLE
Add Apache Airflow Helm Chart Release 1.22.0 to chart index file

### DIFF
--- a/landing-pages/site/static/index.yaml
+++ b/landing-pages/site/static/index.yaml
@@ -21,6 +21,175 @@ entries:
   - annotations:
       artifacthub.io/changes: |
         - description: >
+            Minimum Helm version was updated to 3.19.0
+          kind: changed
+          links:
+          - name: '#66970'
+            url: https://github.com/apache/airflow/pull/66970
+        - description: >
+            Default Airflow image is updated to 3.2.2 (previously 3.2.1)
+          kind: changed
+          links:
+          - name: '#67681'
+            url: https://github.com/apache/airflow/pull/67681
+        - description: >
+            Added support for configuring enableServiceLinks (default will become false in Chart 2.0)
+          kind: added
+          links:
+          - name: '#67447'
+            url: https://github.com/apache/airflow/pull/67447
+        - description: Add optional OTel service to the Airflow Helm Chart
+          kind: added
+          links:
+          - name: '#64902'
+            url: https://github.com/apache/airflow/pull/64902
+        - description: Add ``serviceAccountTokenVolume`` to cleanup cron
+          kind: added
+          links:
+          - name: '#67446'
+            url: https://github.com/apache/airflow/pull/67446
+        - description: Add ``requirePersistence`` option to worker ``logGroomerSidecar``
+          kind: added
+          links:
+          - name: '#65884'
+            url: https://github.com/apache/airflow/pull/65884
+        - description: Add checksum for api-server config in API server deployment
+          kind: changed
+          links:
+          - name: '#66468'
+            url: https://github.com/apache/airflow/pull/66468
+        - description: Fix Helm chart executor label to support executor aliases
+          kind: fixed
+          links:
+          - name: '#67762'
+            url: https://github.com/apache/airflow/pull/67762
+        - description: Fix triggerer KEDA database connection rendering
+          kind: fixed
+          links:
+          - name: '#67538'
+            url: https://github.com/apache/airflow/pull/67538
+        - description: Fix Celery worker liveness probe hostname lookup
+          kind: fixed
+          links:
+          - name: '#67471'
+            url: https://github.com/apache/airflow/pull/67471
+        - description: Fix Go template error comparing slice to nil using ``eq``
+          kind: fixed
+          links:
+          - name: '#64032'
+            url: https://github.com/apache/airflow/pull/64032
+        - description: Fix Kubernetes worker service account values
+          kind: fixed
+          links:
+          - name: '#66598'
+            url: https://github.com/apache/airflow/pull/66598
+        - description: Add binding for ``workers.kubernetes`` and condition workers ServiceAccount
+          kind: fixed
+          links:
+          - name: '#66730'
+            url: https://github.com/apache/airflow/pull/66730
+        - description: Fix launcher RBAC for executor class paths
+          kind: fixed
+          links:
+          - name: '#66208'
+            url: https://github.com/apache/airflow/pull/66208
+        - description: Fix task log access with NetworkPolicies for Airflow 2 and 3
+          kind: fixed
+          links:
+          - name: '#65754'
+            url: https://github.com/apache/airflow/pull/65754
+        - description: Add missing ``tpl`` rendering for ServiceAccount annotations
+          kind: fixed
+          links:
+          - name: '#66095'
+            url: https://github.com/apache/airflow/pull/66095
+        - description: Fix go-template ``if`` statements for log groomer retention values
+          kind: fixed
+          links:
+          - name: '#66012'
+            url: https://github.com/apache/airflow/pull/66012
+        - description: Fix database cleanup lifecycle hooks
+          kind: fixed
+          links:
+          - name: '#65881'
+            url: https://github.com/apache/airflow/pull/65881
+        - description: Fix cleanup pod lifecycle hooks not being applied
+          kind: fixed
+          links:
+          - name: '#65764'
+            url: https://github.com/apache/airflow/pull/65764
+        - description: Fix deprecation warning
+          kind: fixed
+          links:
+          - name: '#66238'
+            url: https://github.com/apache/airflow/pull/66238
+        - description: 'Docs: Expand Helm Chart upgrade tasks in the Airflow 3 migration guide'
+          kind: changed
+          links:
+          - name: '#66118'
+            url: https://github.com/apache/airflow/pull/66118
+        - description: 'Misc: Change job/pod role bindings rendering and refactor related
+            tests'
+          kind: changed
+          links:
+          - name: '#66626'
+            url: https://github.com/apache/airflow/pull/66626
+        - description: 'Misc: Standardize on ``Dag`` capitalization in chart wording'
+          kind: changed
+          links:
+          - name: '#66114'
+            url: https://github.com/apache/airflow/pull/66114
+      artifacthub.io/links: |
+        - name: Documentation
+          url: https://airflow.apache.org/docs/helm-chart/1.22.0/
+      artifacthub.io/screenshots: |
+        - title: Home Page
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/home_dark.png
+        - title: Dag Overview Dashboard
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_dashboard.png
+        - title: Dags View
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dags.png
+        - title: Assets View
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/asset_view.png
+        - title: Grid View
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_grid.png
+        - title: Graph View
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_graph.png
+        - title: Variable View
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/variable_hidden.png
+        - title: Code View
+          url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_code.png
+    apiVersion: v2
+    appVersion: 3.2.2
+    created: "2026-06-01T00:56:29.997009+02:00"
+    dependencies:
+    - condition: postgresql.enabled
+      name: postgresql
+      repository: https://charts.bitnami.com/bitnami
+      version: 13.2.24
+    description: The official Helm chart to deploy Apache Airflow, a platform to programmatically
+      author, schedule, and monitor workflows
+    digest: 1f7d1dfe3d58e2c54899950aba907a43625a18c8b6fb3c54760c21592129a5b6
+    home: https://airflow.apache.org/
+    icon: https://airflow.apache.org/images/airflow_dark_bg.png
+    keywords:
+    - apache
+    - airflow
+    - workflow
+    - scheduler
+    maintainers:
+    - email: dev@airflow.apache.org
+      name: Apache Airflow PMC
+    name: airflow
+    sources:
+    - https://github.com/apache/airflow
+    type: application
+    urls:
+    - https://downloads.apache.org/airflow/helm-chart/1.22.0/airflow-1.22.0.tgz
+    version: 1.22.0
+  - annotations:
+      artifacthub.io/changes: |
+        - description: >
             Workers config options have been moved under workers.celery.* and workers.kubernetes.*:
             safeToEvict, hostAliases, priorityClassName, runtimeClassName, schedulerName,
             serviceAccount, extraContainers, extraInitContainers, extraVolumes, affinity,
@@ -175,7 +344,7 @@ entries:
     - https://github.com/apache/airflow
     type: application
     urls:
-    - https://downloads.apache.org/airflow/helm-chart/1.21.0/airflow-1.21.0.tgz
+    - https://archive.apache.org/dist/airflow/helm-chart/1.21.0/airflow-1.21.0.tgz
     version: 1.21.0
   - annotations:
       artifacthub.io/changes: |
@@ -369,7 +538,7 @@ entries:
     - https://github.com/apache/airflow
     type: application
     urls:
-    - https://dist.apache.org/repos/dist/release/airflow/helm-chart/1.20.0/airflow-1.20.0.tgz
+    - https://archive.apache.org/dist/airflow/helm-chart/1.20.0/airflow-1.20.0.tgz
     version: 1.20.0
   - annotations:
       artifacthub.io/changes: |
@@ -3667,4 +3836,4 @@ entries:
     urls:
     - https://archive.apache.org/dist/airflow/helm-chart/1.0.0/airflow-1.0.0.tgz
     version: 1.0.0
-generated: "2026-04-24T21:52:59.027501923+02:00"
+generated: "2026-06-01T00:56:29.985541+02:00"


### PR DESCRIPTION
Adds the 1.22.0 chart to the published Helm repo index (`index.yaml`):

- `1.22.0` → https://downloads.apache.org/airflow/helm-chart/1.22.0/airflow-1.22.0.tgz (new release)
- Repoints `1.21.0` and `1.20.0` to https://archive.apache.org/... since those
  versions were removed from `dist/release` per ASF release policy (only the
  latest `1.22.0` is kept in `dist/release`; older versions remain permanently
  available from the archive).

Part of the Apache Airflow Helm Chart 1.22.0 release.

---

Generated-by: Claude Code (Opus 4.8); reviewed by @potiuk before posting