### PR TITLE
Point helm-chart 1.22.0 index entry at archive.apache.org

### DIFF
--- a/landing-pages/site/static/index.yaml
+++ b/landing-pages/site/static/index.yaml
@@ -185,7 +185,7 @@ entries:
     - https://github.com/apache/airflow
     type: application
     urls:
-    - https://downloads.apache.org/airflow/helm-chart/1.22.0/airflow-1.22.0.tgz
+    - https://archive.apache.org/dist/airflow/helm-chart/1.22.0/airflow-1.22.0.tgz
     version: 1.22.0
   - annotations:
       artifacthub.io/changes: |


### PR DESCRIPTION
The `1.22.0` entry in the published Helm repo index (`landing-pages/site/static/index.yaml`) was added with a `downloads.apache.org` URL. `downloads.apache.org` only serves the latest release, so that URL will 404 as soon as the next chart version ships, whereas `archive.apache.org` permanently retains every released version. This repoints it at `archive.apache.org/dist`, matching every other entry in the index.

The release-doc fix that prevents this recurring is apache/airflow#67988.

Generated-by: Claude Code (Opus 4.8)