### PR TITLE
Fix Summit 2026 banner missing on home/blog/community pages

### DIFF
--- a/landing-pages/site/layouts/_partials/navbar.html
+++ b/landing-pages/site/layouts/_partials/navbar.html
@@ -18,7 +18,10 @@
 */}}
 
 {{ $cover := .HasShortcode "blocks/cover" }}
-<nav class="js-navbar-scroll navbar" aria-label="Main navigation">
+<a href="https://airflowsummit.org" target="_blank" class="d-block fixed-top px-3 py-2 bg-success text-center text-bold text-white">
+    Airflow Summit 2026 is coming August 31 - September 2 in Austin, TX. Register now to secure your spot!
+</a>
+<nav class="js-navbar-scroll navbar" aria-label="Main navigation" style="top: 40px;">
 
     <div class="navbar__icon-container">
         <a href="{{ .Site.Home.RelPermalink }}" aria-label="Apache Airflow home">


### PR DESCRIPTION
PR #1566 added the Airflow Summit 2026 banner only to `layouts/partials/navbar.html`, but most pages render the navbar from `layouts/_partials/navbar.html` (Hugo's current partial convention, which takes precedence), so the banner didn't show on the home page, blog, community, or use-cases. This mirrors the banner into the `_partials` copy so it appears site-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)