### PR TITLE
Show suggest-change label in a compact pill on docs pages

### DIFF
--- a/landing-pages/site/assets/scss/_suggest-change.scss
+++ b/landing-pages/site/assets/scss/_suggest-change.scss
@@ -30,3 +30,40 @@
     visibility: hidden;
     transition: opacity 0.5s ease, visibility 0s linear;
 }
+
+// Compact pill: GitHub icon + visible wrapping label (Sphinx docs only).
+.base-layout--button .suggest-change-link {
+    $label-max-width: 8rem;
+
+    max-width: calc(#{$label-max-width} + 2.5rem);
+
+    .btn-with-icon {
+        display: inline-flex;
+        align-items: center;
+        width: auto;
+        height: auto;
+        padding: 5px 8px;
+        gap: 5px;
+        border-radius: 10px;
+
+        &:hover {
+            background: rgba(128, 128, 128, 0.12);
+        }
+
+        svg {
+            flex: 0 0 auto;
+            transform: scale(1.25);
+            transform-origin: center;
+        }
+
+        span {
+            flex: 1 1 auto;
+            max-width: $label-max-width;
+            font-size: 12px;
+            line-height: 1.25;
+            white-space: normal;
+            overflow-wrap: anywhere;
+            text-align: center;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The "Suggest a change on this page" control on Sphinx docs pages was too large and crowded the right margin,
- Per feedback on this PR, this updates the control to **Option B**: a compact pill with the GitHub icon and visible **"Suggest a change on this page"** text. It is smaller than the original wide button while keeping clear affordance.
<img width="800" height="451" alt="Compact suggest-change pill with visible label" src="https://github.com/user-attachments/assets/4f89465d-57be-4d71-a8c2-2ccf685d84e1" />

## Changes
- `landing-pages/site/assets/scss/_suggest-change.scss`: Override `.btn-with-icon` inside `.suggest-change-link` to render as a compact pill (icon + wrapping label).
- CSS-only; no HTML, template, or JS changes.

## In scope
- Sphinx-built docs pages only (`.suggest-change-link` under `.base-layout--button`).

## Out of scope
A pre-existing duplicate screen-reader announcement on this affordance (nested `<a><button>` markup in `suggest_change_button.html`) is unrelated to this sizing change and can be addressed in a follow-up PR.

## Test plan
- [x] Stylelint passes locally (`prek run --files landing-pages/site/assets/scss/_suggest-change.scss --stage pre-commit`)
- [x] Rebuilt theme CSS (`yarn run build` in `landing-pages/`, then `./site.sh prepare-theme`)
- [x] Verified on a mirrored production docs page: compact pill, visible label, TOC hover hide/show, sticky lower-right on long pages

**Resolves**: apache/airflow#16654
