### PR TITLE
Add ClickHouse provider to docs index

### DIFF
--- a/landing-pages/site/content/en/docs/_index.md
+++ b/landing-pages/site/content/en/docs/_index.md
@@ -105,6 +105,8 @@ Providers packages include integrations with third party projects. They are vers
 
   <li><a href="/docs/apache-airflow-providers-celery/stable/index.html"><code>Celery</code></a></li>
 
+  <li><a href="/docs/apache-airflow-providers-clickhousedb/stable/index.html"><code>ClickHouse</code></a></li>
+
   <li><a href="/docs/apache-airflow-providers-cloudant/stable/index.html"><code>Cloudant</code></a></li>
 
   <li><a href="/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html"><code>CNCF Kubernetes</code></a></li>


### PR DESCRIPTION
The apache-airflow-providers-clickhousedb provider has been released, so it should appear in the providers list on the documentation site.