### PR TITLE
Exclude gitignored files from sphinx theme hash computation

### DIFF
--- a/sphinx_airflow_theme/check_and_bump_version.py
+++ b/sphinx_airflow_theme/check_and_bump_version.py
@@ -40,14 +40,45 @@ VERSION_FILE = THEME_DIR / "LATEST_VERSION.txt"
 INIT_FILE = THEME_MODULE / "__init__.py"
 
 
+def _gitignored_paths_under(directory: Path) -> set[str]:
+    """Return the set of gitignored file paths under *directory*, relative to REPO_ROOT.
+
+    Uses ``git ls-files --others --ignored --exclude-standard`` so the same rules
+    a fresh CI checkout applies are used here — otherwise files that only exist
+    locally (e.g. ``static/_gen/`` populated by ``./site.sh build-site``) would
+    make the local hash diverge from the one CI computes.
+    """
+    try:
+        output = subprocess.check_output(
+            [
+                "git",
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "--",
+                str(directory),
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return set()
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
 def compute_theme_hash() -> str:
     """Hash all theme files (excluding version lines in __init__.py) plus pyproject.toml.
 
     File paths are included as relative paths so the hash is stable regardless of working directory.
+    Gitignored paths are skipped so the hash matches on any checkout (local or CI).
     """
     h = hashlib.sha256()
+    gitignored = _gitignored_paths_under(THEME_MODULE)
     for f in sorted(THEME_MODULE.rglob("*")):
         if not f.is_file() or "__pycache__" in f.parts or f.name == ".DS_Store":
+            continue
+        if str(f.relative_to(REPO_ROOT)) in gitignored:
             continue
         relative = f.relative_to(REPO_ROOT)
         h.update(f"{relative}\n".encode())


### PR DESCRIPTION
## Why
Currently,  `check_and_bump_version.py` walks all files under `THEME_MODULE` and only skips `__pycache__` and `.DS_Store`. But it does not skip gitignored files like `sphinx_airflow_theme/sphinx_airflow_theme/static/_gen/`.

That folder only exists after you run `./site.sh build-site` locally. Since CI never has it, the local hash and CI hash are different, and the `check-sphinx-theme-version` hook keeps saying "bump version" every time.

I hit this while working on #1580. Every push, CI told me to bump. I bumped, pushed, CI told me to bump again. It never stops.

## What
The fix uses `git ls-files --others --ignored --exclude-standard` to skip gitignored files, so local and CI compute the same hash.

I also checked that the hash after this fix matches the currently stored hash on upstream main (`421d922...`), so this PR itself does not need a version bump.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7)
