### PR TITLE
Group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
       interval: daily
     groups:
       npm-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
         patterns:
           - "*"
   - package-ecosystem: github-actions
@@ -38,6 +43,11 @@ updates:
       interval: daily
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
   - package-ecosystem: pre-commit


### PR DESCRIPTION
Six of the recently merged Dependabot PRs arrived ungrouped, one per bump:

- #1608 `shell-quote`, #1607 `fast-uri`, #1605 `immutable`, #1604 `svgo`
- #1568 `launch-editor`, #1541 `qs` + `express`

All six are **security** updates (each has a matching high-severity
Dependabot alert; all are transitive deps of `landing-pages`), not version
updates. A group in `dependabot.yml` only covers security updates when it
declares `applies-to: security-updates` — the existing `patterns: "*"`
groups default to `version-updates`, so alert-driven bumps bypassed the
grouping entirely and opened individual PRs.

This adds a parallel security-updates group for the `npm` and
`github-actions` ecosystems so those bumps get batched the same way regular
version updates already are.

`pre-commit` is deliberately left alone — Dependabot does not issue security
updates for that ecosystem, so a second group there would be dead config.

Note that `cooldown` does not apply to security updates, so these will still
open promptly — just bundled into one PR instead of six. The currently open
`js-yaml` / `brace-expansion` alerts should come through as a single grouped
PR on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)