### PR TITLE
Add OptimaFlo to ecosystem page

### DIFF
--- a/landing-pages/site/content/en/ecosystem/_index.md
+++ b/landing-pages/site/content/en/ecosystem/_index.md
@@ -47,6 +47,8 @@ If you would you like to be included on this page, please reach out to the [Apac
 
 [STACKIT Workflows](https://docs.stackit.cloud/products/data-and-ai/workflows/) - Managed Apache Airflow on STACKIT Cloud
 
+[OptimaFlo](https://optimaflo.io) - Managed Apache Airflow inside your own AWS or GCP account, as part of an AI-operated data platform on Apache Iceberg
+
 &nbsp;
 
 ## Airflow Technology Consultancy Support


### PR DESCRIPTION
Adds OptimaFlo under Airflow as a Service. Runs managed Apache Airflow inside the customer's own AWS or GCP account, as part of a data platform built on Apache Iceberg and Apache Polaris.